### PR TITLE
Harden AdminConfig REST contracts

### DIFF
--- a/packages/AdminConfig/docs/rest-api.md
+++ b/packages/AdminConfig/docs/rest-api.md
@@ -75,7 +75,10 @@ inside `context`:
 ```
 
 Supported context keys are `post_id`, `term_id`, `user_id`, `comment_id`, and
-`network_id`.
+`network_id`. Read endpoints and mutation endpoints share the same context
+requirement; object-backed schema and values reads return `missing_store_context`
+instead of silently falling back to defaults when the required object ID is
+missing.
 
 ## Responses
 

--- a/packages/AdminConfig/src/Rest/Controllers/SchemaController.php
+++ b/packages/AdminConfig/src/Rest/Controllers/SchemaController.php
@@ -36,12 +36,16 @@ final class SchemaController {
 			return $schema;
 		}
 
-		$context = ContextResolver::from_request( $request );
+		try {
+			$values = $this->runtime->store( $schema->id(), ContextResolver::from_request( $request ) )->all();
+		} catch ( MissingStoreContextException $exception ) {
+			return $this->missing_context_error( $exception );
+		}
 
 		return rest_ensure_response(
 			array(
 				'schema' => SchemaClientConfig::from_compiled( $schema ),
-				'values' => $this->runtime->all( $schema->id(), $context ),
+				'values' => $values,
 			)
 		);
 	}
@@ -53,11 +57,15 @@ final class SchemaController {
 			return $schema;
 		}
 
-		$context = ContextResolver::from_request( $request );
+		try {
+			$values = $this->runtime->store( $schema->id(), ContextResolver::from_request( $request ) )->all();
+		} catch ( MissingStoreContextException $exception ) {
+			return $this->missing_context_error( $exception );
+		}
 
 		return ResponseFactory::success(
 			array(
-				'values' => $this->runtime->all( $schema->id(), $context ),
+				'values' => $values,
 			)
 		);
 	}

--- a/packages/AdminConfig/tests/Unit/RestEndpointsTest.php
+++ b/packages/AdminConfig/tests/Unit/RestEndpointsTest.php
@@ -289,30 +289,7 @@ final class RestEndpointsTest extends TestCase {
 	}
 
 	public function testMissingMetaContextReturnsStableRestErrorShape(): void {
-		$runtime = new Runtime();
-		$runtime->register(
-			array(
-				'id'        => 'rest_meta',
-				'container' => array(
-					'type' => 'metabox',
-				),
-				'store'     => array(
-					'type' => 'post_meta',
-					'key'  => '_rest_meta',
-				),
-				'sections'  => array(
-					'general' => array(
-						'fields' => array(
-							array(
-								'id'      => 'badge_text',
-								'type'    => 'text',
-								'default' => 'Featured',
-							),
-						),
-					),
-				),
-			)
-		);
+		$runtime = $this->runtime_with_meta_schema();
 
 		$response = ( new SchemaController( $runtime ) )->save(
 			$this->request(
@@ -330,6 +307,26 @@ final class RestEndpointsTest extends TestCase {
 		$this->assertSame( 400, $response->get_error_data()['status'] );
 		$this->assertFalse( $response->get_error_data()['success'] );
 		$this->assertStringContainsString( 'requires one of', $response->get_error_data()['data']['message'] );
+	}
+
+	public function testSchemaEndpointReturnsMissingContextForObjectBackedStore(): void {
+		$response = ( new SchemaController( $this->runtime_with_meta_schema() ) )->schema(
+			$this->request( array( 'id' => 'rest_meta' ) )
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'missing_store_context', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
+	}
+
+	public function testValuesEndpointReturnsMissingContextForObjectBackedStore(): void {
+		$response = ( new SchemaController( $this->runtime_with_meta_schema() ) )->values(
+			$this->request( array( 'id' => 'rest_meta' ) )
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'missing_store_context', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] );
 	}
 
 	public function testPermissionCallbackReturnsForbiddenRestErrorShape(): void {
@@ -480,6 +477,32 @@ final class RestEndpointsTest extends TestCase {
 		$this->assertSame( Runtime::MAX_DATA_SOURCE_PER_PAGE, $seen_args['per_page'] );
 	}
 
+	public function testDataSourceEndpointUsesDefaultPerPage(): void {
+		$runtime   = $this->runtime_with_schema();
+		$seen_args = array();
+
+		$runtime->register_data_source(
+			'campaigns',
+			static function ( array $args ) use ( &$seen_args ): array {
+				$seen_args = $args;
+
+				return array();
+			}
+		);
+
+		$response = ( new SchemaController( $runtime ) )->data_source(
+			$this->request(
+				array(
+					'id'       => 'rest_test',
+					'field_id' => 'campaign',
+				)
+			)
+		);
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 20, $seen_args['per_page'] );
+	}
+
 	public function testLegacyAjaxDataSourceClampsPerPage(): void {
 		$runtime   = $this->runtime_with_schema();
 		$seen_args = array();
@@ -551,6 +574,35 @@ final class RestEndpointsTest extends TestCase {
 								'type'    => 'ajax_select',
 								'source'  => 'campaigns',
 								'default' => '',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		return $runtime;
+	}
+
+	private function runtime_with_meta_schema(): Runtime {
+		$runtime = new Runtime();
+		$runtime->register(
+			array(
+				'id'        => 'rest_meta',
+				'container' => array(
+					'type' => 'metabox',
+				),
+				'store'     => array(
+					'type' => 'post_meta',
+					'key'  => '_rest_meta',
+				),
+				'sections'  => array(
+					'general' => array(
+						'fields' => array(
+							array(
+								'id'      => 'badge_text',
+								'type'    => 'text',
+								'default' => 'Featured',
 							),
 						),
 					),


### PR DESCRIPTION
## Summary
- Make schema and values REST reads return `missing_store_context` for object-backed stores without context instead of silently falling back to defaults.
- Add unit coverage for schema/values missing-context reads and data-source default `per_page` behavior.
- Document the shared object-store context requirement for REST reads and mutations.

## Verification
- `composer test:unit`
- `composer ci`
- `npm run test:wp:rest-only`