### PR TITLE
[codex] Align AdminConfig phase documentation

### DIFF
--- a/packages/AdminConfig/docs/block-editor-migration.md
+++ b/packages/AdminConfig/docs/block-editor-migration.md
@@ -69,9 +69,10 @@ verification set.
 
 ## Phase 3 Entry Criteria
 
-The first Phase 3 PR should only mount the block-panel bundle in the editor and
-create a runtime with editor context. It should not migrate the full field UI
-yet.
+Phase 3 started by mounting the block-panel bundle in the editor and creating a
+runtime with editor context before broadening field-control coverage. Later
+Phase 3 slices can add controls only when they stay on the REST contract and keep
+classic admin regression coverage green.
 
 ## Phase 3 Current Step
 
@@ -115,7 +116,7 @@ Acceptance for this slice:
 - Advanced, structured, media, async, reset, and import/export controls stay out
   of this slice.
 
-## Non-Goals For Phase 1
+## Non-Goals For The Current Block-Panel Slice
 
 - Do not rewrite classic field markup in React yet.
 - Do not change PHP schema definitions to fit Gutenberg-specific components.

--- a/packages/AdminConfig/docs/phase-2-stabilization.md
+++ b/packages/AdminConfig/docs/phase-2-stabilization.md
@@ -66,8 +66,10 @@ Passing this set means:
 - Core JavaScript runtime helpers are covered by lightweight contract tests.
 - REST-only, default single-site, and multisite wp-env rehearsals remain green.
 
-## Next Gate
+## Phase 3 Handoff
 
-Phase 3 should start only after this stable point is green on `main`. The first
-Phase 3 PR should mount the block-panel script in the editor and create the
-runtime with `post_id` context, but it should not migrate field controls yet.
+At this Phase 2 checkpoint, the next gate was to mount the block-panel script in
+the editor and create the runtime with `post_id` context before migrating field
+controls. Current block-editor capabilities are tracked in
+`docs/block-editor-migration.md`; this document remains a Phase 2 baseline
+snapshot.

--- a/packages/AdminConfig/docs/support-matrix.md
+++ b/packages/AdminConfig/docs/support-matrix.md
@@ -29,7 +29,7 @@
 - Comment edit screens
 - Block editor document settings panel for post/page metabox schemas
 
-## Built-In Field Coverage
+## Package-Level Built-In Field Coverage
 
 - Core primitives
 - Extended primitives and presentation fields


### PR DESCRIPTION
## Summary
- clarify that the Phase 3 entry gate has already moved from mounting into control coverage
- mark the Phase 2 stabilization page as a historical baseline snapshot
- scope support-matrix built-in field coverage to the package level so it does not overstate block-editor parity

## Review notes
- PR #32 is already merged, had no review threads or comments, and its AdminConfig CI workflow completed successfully.
- Code/docs parity was checked against the current block-panel registry, demo metabox schema, block editor E2E coverage, and support docs.

## Validation
- `git diff --check`