### PR TITLE
[codex] Add AdminConfig structured block panel controls

### DIFF
--- a/packages/AdminConfig/CHANGELOG.md
+++ b/packages/AdminConfig/CHANGELOG.md
@@ -49,6 +49,9 @@ The format follows Keep a Changelog and the package uses Semantic Versioning onc
 - Block editor panel media controls for `upload`, `media`, and `gallery`
   fields, including media-library selection, REST save serialization, and
   browser persistence coverage.
+- Block editor panel structured controls for `fieldset`, `group`,
+  `dimensions`, and `spacing`, including nested value paths and validation-error
+  replay coverage.
 
 ### Changed
 - The package is now documented as an open-source runtime with a clearer contributor onboarding path and explicit support expectations.
@@ -83,6 +86,8 @@ The format follows Keep a Changelog and the package uses Semantic Versioning onc
   values by path.
 - Block editor field metadata now exposes media control labels and library
   constraints through the client schema payload.
+- The client schema payload now exposes nested field metadata and design-control
+  flags needed by structured block-panel controls.
 - Block editor color/date/range controls now avoid duplicate input/change state
   updates.
 - Block editor number controls now preserve an explicitly cleared empty value

--- a/packages/AdminConfig/docs/block-editor-field-matrix.md
+++ b/packages/AdminConfig/docs/block-editor-field-matrix.md
@@ -6,6 +6,10 @@ This matrix defines the Phase 3 block-panel contract for AdminConfig field
 types. The block editor is not the limiting factor; the status describes how far
 the AdminConfig block-panel runtime has migrated each field family.
 
+Metabox and post-meta schema fields use custom Panel UI as the default block
+editor surface. `InnerBlocks` remains reserved for future content-structure
+features where values belong in block content rather than AdminConfig storage.
+
 ## Status Definitions
 
 - `editable`: rendered in the block panel, updates client state, participates in
@@ -39,6 +43,10 @@ the AdminConfig block-panel runtime has migrated each field family.
 | `upload` | URL-backed media-library selection. |
 | `media` | Single attachment selection saved through REST by attachment ID. |
 | `gallery` | Ordered attachment ID list with media-library selection. |
+| `fieldset` | Nested object editing with child controls and dotted validation paths. |
+| `group` | Repeatable object list editing with child controls. |
+| `dimensions` | Width/height numeric object editing with unit selection. |
+| `spacing` | Box-side numeric object editing with unit selection. |
 
 ## Read-Only
 
@@ -46,8 +54,8 @@ the AdminConfig block-panel runtime has migrated each field family.
 | --- | --- |
 | `heading`, `subheading`, `content`, `notice` | Presentation-only fields; no persisted value should enter the save payload. |
 | `image_select`, `palette`, `icon` | Needs richer visual picker UI before editing. |
-| `fieldset`, `group`, `typography` | Needs nested value-path updates and nested validation-error replay. |
-| `background`, `border`, `dimensions`, `link_color`, `spacing` | Needs composite design-control editing and nested value-path updates. |
+| `typography` | Needs full typography-specific UI before editing. |
+| `background`, `border`, `link_color` | Needs composite design-control editing beyond numeric box values. |
 | `accordion`, `tabbed`, `sorter` | Needs structured collection state and ordering semantics. |
 | `code_editor`, `wp_editor` | Needs editor-specific component integration and sanitization-aware UX. |
 | `ajax_select` | Needs REST data-source search, pagination, and async selection UX in the block panel. |

--- a/packages/AdminConfig/examples/schema-demo-plugin/src/SchemaDemoPlugin.php
+++ b/packages/AdminConfig/examples/schema-demo-plugin/src/SchemaDemoPlugin.php
@@ -490,6 +490,58 @@ final class SchemaDemoPlugin {
 							'default'     => array(),
 						),
 						array(
+							'id'          => 'entry_dimensions',
+							'type'        => 'dimensions',
+							'label'       => __( 'Entry card size', 'lerm-admin-config-demo' ),
+							'description' => __( 'A nested dimensions object rendered by the block editor panel.', 'lerm-admin-config-demo' ),
+							'units'       => array( 'px', '%', 'rem' ),
+							'default'     => array(
+								'width'  => '320',
+								'height' => '180',
+								'unit'   => 'px',
+							),
+						),
+						array(
+							'id'          => 'entry_spacing',
+							'type'        => 'spacing',
+							'label'       => __( 'Entry card spacing', 'lerm-admin-config-demo' ),
+							'description' => __( 'A nested spacing object rendered by the block editor panel.', 'lerm-admin-config-demo' ),
+							'units'       => array( 'px', 'rem' ),
+							'default'     => array(
+								'top'    => '8',
+								'right'  => '12',
+								'bottom' => '8',
+								'left'   => '12',
+								'unit'   => 'px',
+							),
+						),
+						array(
+							'id'          => 'entry_links',
+							'type'        => 'group',
+							'label'       => __( 'Entry links', 'lerm-admin-config-demo' ),
+							'description' => __( 'A repeatable group rendered by the block editor panel.', 'lerm-admin-config-demo' ),
+							'fields'      => array(
+								array(
+									'id'      => 'label',
+									'type'    => 'text',
+									'label'   => __( 'Link label', 'lerm-admin-config-demo' ),
+									'default' => __( 'Read more', 'lerm-admin-config-demo' ),
+								),
+								array(
+									'id'      => 'url',
+									'type'    => 'url',
+									'label'   => __( 'Link URL', 'lerm-admin-config-demo' ),
+									'default' => 'https://example.test/read-more',
+								),
+							),
+							'default'     => array(
+								array(
+									'label' => __( 'Read more', 'lerm-admin-config-demo' ),
+									'url'   => 'https://example.test/read-more',
+								),
+							),
+						),
+						array(
 							'id'          => 'entry_icon',
 							'type'        => 'icon',
 							'label'       => __( 'Entry icon', 'lerm-admin-config-demo' ),

--- a/packages/AdminConfig/resources/block-panel/index.js
+++ b/packages/AdminConfig/resources/block-panel/index.js
@@ -28,9 +28,6 @@ const READ_ONLY_CONTROL_TYPES = new Set([
 	'border',
 	'code_editor',
 	'content',
-	'dimensions',
-	'fieldset',
-	'group',
 	'heading',
 	'icon',
 	'image_select',
@@ -38,7 +35,6 @@ const READ_ONLY_CONTROL_TYPES = new Set([
 	'notice',
 	'palette',
 	'sorter',
-	'spacing',
 	'subheading',
 	'tabbed',
 	'typography',
@@ -576,12 +572,18 @@ const createPanelComponent = (config, Panel, element) => {
 						[
 							control({
 								components,
+								controls: runtime.controls,
 								createElement,
 								error,
+								errors: state.errors || {},
 								field,
 								inputId: `${ panelSlug(String(config.schemaId || 'schema')) }-${ fieldId }`,
 								onChange: (value) => {
 									runtime.updateValue(fieldId, value);
+									setState(runtime.getState());
+								},
+								onPathChange: (path, value) => {
+									runtime.updateValue(path, value);
 									setState(runtime.getState());
 								},
 								value: fieldValue(state.values || {}, fieldId, field.default),

--- a/packages/AdminConfig/resources/controls/index.js
+++ b/packages/AdminConfig/resources/controls/index.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const { asRecord } = require('../core/records');
+const { asRecord, asRecordArray } = require('../core/records');
 
 /**
  * @typedef {(props: Record<string, unknown>) => unknown} FieldControl
@@ -97,21 +97,27 @@ const errorMessage = (error) => asArray(error).length
  * @param {Record<string, unknown>} props
  * @returns {{
  *   components: Record<string, Function>,
+ *   controls: { get: (type: string) => FieldControl|null },
  *   createElement: Function,
  *   error: string,
+ *   errors: Record<string, string|string[]>,
  *   field: Record<string, unknown>,
  *   inputId: string,
  *   onChange: Function,
+ *   onPathChange: Function,
  *   value: unknown
  * }}
  */
 const normalizeProps = (props) => ({
 	components: /** @type {Record<string, Function>} */ (asRecord(props.components)),
+	controls: /** @type {{ get: (type: string) => FieldControl|null }} */ (props.controls || { get: () => null }),
 	createElement: /** @type {Function} */ (props.createElement),
 	error: errorMessage(props.error),
+	errors: /** @type {Record<string, string|string[]>} */ (asRecord(props.errors)),
 	field: asRecord(props.field),
 	inputId: stringValue(props.inputId),
 	onChange: /** @type {Function} */ (props.onChange),
+	onPathChange: /** @type {Function} */ (props.onPathChange || (() => {})),
 	value: props.value,
 });
 
@@ -145,6 +151,159 @@ const numericValue = (value, field) => {
 	}
 
 	return current !== '' ? current : stringValue(field.default || 0);
+};
+
+/**
+ * @param {Record<string, unknown>} field
+ * @returns {string}
+ */
+const fieldControlType = (field) => {
+	const client = asRecord(field.client);
+
+	return stringValue(field.control || client.control || field.type || 'text') || 'text';
+};
+
+/**
+ * @param {Record<string, unknown>} field
+ * @returns {Array<Record<string, unknown>>}
+ */
+const childFields = (field) => asRecordArray(field.fields);
+
+/**
+ * @param {string|string[]} path
+ * @returns {string[]}
+ */
+const pathTokens = (path) => (Array.isArray(path) ? path : stringValue(path).split('.'))
+	.map((token) => stringValue(token).trim())
+	.filter(Boolean);
+
+/**
+ * @param {string[]} path
+ * @returns {string}
+ */
+const pathKey = (path) => path.join('.');
+
+/**
+ * @param {Record<string, string|string[]>} errors
+ * @param {string|string[]} path
+ * @returns {string}
+ */
+const errorForPath = (errors, path) => errorMessage(errors[pathKey(pathTokens(path))]);
+
+/**
+ * @param {Record<string, unknown>} field
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+const fieldValue = (field, value) => typeof value === 'undefined' ? field.default : value;
+
+/**
+ * @param {Record<string, unknown>} field
+ * @param {Record<string, unknown>} parentValue
+ * @returns {unknown}
+ */
+const childValue = (field, parentValue) => {
+	const fieldId = stringValue(field.id);
+
+	return Object.prototype.hasOwnProperty.call(parentValue, fieldId)
+		? parentValue[fieldId]
+		: field.default;
+};
+
+/**
+ * @param {Array<Record<string, unknown>>} fields
+ * @returns {Record<string, unknown>}
+ */
+const defaultNestedValue = (fields) => fields.reduce((values, field) => {
+	const fieldId = stringValue(field.id);
+
+	if (fieldId) {
+		values[fieldId] = Object.prototype.hasOwnProperty.call(field, 'default') ? field.default : '';
+	}
+
+	return values;
+}, {});
+
+/**
+ * @param {unknown} value
+ * @returns {Array<Record<string, unknown>>}
+ */
+const groupItems = (value) => Array.isArray(value) ? value.map(asRecord) : [];
+
+/**
+ * @param {ReturnType<typeof normalizeProps>} normalized
+ * @param {Record<string, unknown>} field
+ * @param {string[]} path
+ * @param {unknown} value
+ * @returns {unknown}
+ */
+const renderNestedField = (normalized, field, path, value) => {
+	const { components, controls, createElement, errors, inputId, onPathChange } = normalized;
+	const fieldId = stringValue(field.id);
+	const controlType = fieldControlType(field);
+	const control = controls.get(controlType);
+	const exactPath = pathKey(path);
+	const error = errorForPath(errors, path);
+	const label = stringValue(field.label || fieldId);
+
+	if (!fieldId) {
+		return null;
+	}
+
+	if (typeof control !== 'function') {
+		return createElement(
+			'div',
+			{
+				className: 'lerm-admin-config-block-panel__nested-field lerm-admin-config-block-panel__nested-field--unavailable',
+				'data-field-path': exactPath,
+				key: exactPath,
+				role: 'note',
+			},
+			[
+				createElement('strong', { key: 'label' }, label),
+				createElement('p', { key: 'message' }, `Field type "${ controlType }" is not available in this composite field yet.`),
+				error
+					? createElement('p', {
+						className: 'lerm-admin-config-block-panel__field-error',
+						'data-field-error': exactPath,
+						key: 'error',
+					}, error)
+					: null,
+			].filter(Boolean)
+		);
+	}
+
+	return createElement(
+		'div',
+		{
+			className: `lerm-admin-config-block-panel__nested-field${ error ? ' is-error' : '' }`,
+			'data-control-status': 'editable',
+			'data-field-path': exactPath,
+			'data-field-type': controlType,
+			key: exactPath,
+		},
+		[
+			control({
+				components,
+				controls,
+				createElement,
+				error,
+				errors,
+				field,
+				inputId: `${ inputId }-${ path.map((token) => token.replace(/[^a-z0-9_-]+/gi, '-')).join('-') }`,
+				onChange: (nextValue) => onPathChange(path, nextValue),
+				onPathChange,
+				value: fieldValue(field, value),
+			}),
+			error
+				? createElement('p', {
+					className: 'lerm-admin-config-block-panel__field-error',
+					'data-field-error': exactPath,
+					key: 'error',
+				}, error)
+				: null,
+		].filter(Boolean)
+	);
 };
 
 /**
@@ -921,6 +1080,247 @@ const CheckboxControl = (props) => {
 };
 
 /**
+ * @param {Record<string, unknown>} field
+ * @returns {string[]}
+ */
+const fieldUnits = (field) => {
+	const unit = field.unit;
+
+	if (typeof unit === 'string' && unit !== '') {
+		return [ unit ];
+	}
+
+	const units = Array.isArray(field.units) ? field.units.map(stringValue).filter(Boolean) : [ 'px', '%', 'em' ];
+
+	return units.length ? units : [ 'px' ];
+};
+
+/**
+ * @param {Record<string, unknown>} field
+ * @param {string} key
+ * @param {boolean} fallback
+ * @returns {boolean}
+ */
+const fieldFlag = (field, key, fallback) => Object.prototype.hasOwnProperty.call(field, key)
+	? boolValue(field[key])
+	: fallback;
+
+/**
+ * @param {ReturnType<typeof normalizeProps>} normalized
+ * @param {Array<{ key: string, label: string }>} fields
+ * @returns {unknown}
+ */
+const CompositeBoxControl = (normalized, fields) => {
+	const { createElement, field, inputId, onPathChange, value } = normalized;
+	const fieldId = stringValue(field.id);
+	const current = asRecord(value);
+	const units = fieldUnits(field);
+	const showUnits = fieldFlag(field, 'unit', true) && fieldFlag(field, 'show_units', true) && units.length > 1;
+	const label = stringValue(field.label || fieldId);
+	const description = stringValue(field.description);
+	const children = [
+		createElement('legend', { key: 'legend' }, label),
+		description
+			? createElement('p', { className: 'lerm-admin-config-block-panel__field-description', key: 'description' }, description)
+			: null,
+		...fields.map((item) => {
+			const path = [ fieldId, item.key ];
+			const error = errorForPath(normalized.errors, path);
+
+			return createElement(
+				'label',
+				{
+					className: `lerm-admin-config-block-panel__composite-item${ error ? ' is-error' : '' }`,
+					key: item.key,
+				},
+				[
+					createElement('span', { key: 'label' }, item.label),
+					createElement('input', {
+						'aria-invalid': error ? 'true' : undefined,
+						'aria-label': `${ label } ${ item.label }`,
+						id: `${ inputId }-${ item.key }`,
+						key: 'input',
+						onInput: (event) => onPathChange(path, stringValue(changeValue(event))),
+						step: 'any',
+						type: 'number',
+						value: stringValue(current[item.key]),
+					}),
+					error
+						? createElement('span', {
+							className: 'lerm-admin-config-block-panel__field-error',
+							'data-field-error': pathKey(path),
+							key: 'error',
+						}, error)
+						: null,
+				].filter(Boolean)
+			);
+		}),
+		showUnits
+			? createElement(
+				'label',
+				{
+					className: 'lerm-admin-config-block-panel__composite-item',
+					key: 'unit',
+				},
+				[
+					createElement('span', { key: 'label' }, 'Unit'),
+					createElement(
+						'select',
+						{
+							'aria-label': `${ label } unit`,
+							id: `${ inputId }-unit`,
+							key: 'select',
+							onChange: (event) => onPathChange([ fieldId, 'unit' ], stringValue(changeValue(event))),
+							value: stringValue(current.unit || field.default?.unit || units[0]),
+						},
+						units.map((unit) => createElement('option', { key: unit, value: unit }, unit))
+					),
+				]
+			)
+			: null,
+	];
+
+	return createElement(
+		'fieldset',
+		{
+			className: 'lerm-admin-config-block-panel__composite-field',
+		},
+		children.filter(Boolean)
+	);
+};
+
+/**
+ * @param {Record<string, unknown>} props
+ * @returns {unknown}
+ */
+const DimensionsControl = (props) => {
+	const normalized = normalizeProps(props);
+	const fields = [
+		fieldFlag(normalized.field, 'width', true) ? { key: 'width', label: 'Width' } : null,
+		fieldFlag(normalized.field, 'height', true) ? { key: 'height', label: 'Height' } : null,
+	].filter(Boolean);
+
+	return CompositeBoxControl(normalized, fields);
+};
+
+/**
+ * @param {Record<string, unknown>} props
+ * @returns {unknown}
+ */
+const SpacingControl = (props) => {
+	const normalized = normalizeProps(props);
+	const fields = fieldFlag(normalized.field, 'all', false)
+		? [ { key: 'all', label: 'All' } ]
+		: [
+			fieldFlag(normalized.field, 'top', true) ? { key: 'top', label: 'Top' } : null,
+			fieldFlag(normalized.field, 'right', true) ? { key: 'right', label: 'Right' } : null,
+			fieldFlag(normalized.field, 'bottom', true) ? { key: 'bottom', label: 'Bottom' } : null,
+			fieldFlag(normalized.field, 'left', true) ? { key: 'left', label: 'Left' } : null,
+		].filter(Boolean);
+
+	return CompositeBoxControl(normalized, fields);
+};
+
+/**
+ * @param {Record<string, unknown>} props
+ * @returns {unknown}
+ */
+const FieldsetControl = (props) => {
+	const normalized = normalizeProps(props);
+	const { createElement, field, value } = normalized;
+	const fieldId = stringValue(field.id);
+	const fields = childFields(field);
+	const current = asRecord(value);
+	const label = stringValue(field.label || fieldId);
+	const description = stringValue(field.description);
+
+	return createElement(
+		'fieldset',
+		{
+			className: 'lerm-admin-config-block-panel__fieldset',
+		},
+		[
+			createElement('legend', { key: 'legend' }, label),
+			description
+				? createElement('p', { className: 'lerm-admin-config-block-panel__field-description', key: 'description' }, description)
+				: null,
+			...fields.map((child) => renderNestedField(
+				normalized,
+				child,
+				[ fieldId, stringValue(child.id) ],
+				childValue(child, current)
+			)),
+		].filter(Boolean)
+	);
+};
+
+/**
+ * @param {Record<string, unknown>} props
+ * @returns {unknown}
+ */
+const GroupControl = (props) => {
+	const normalized = normalizeProps(props);
+	const { components, createElement, field, onChange, value } = normalized;
+	const Button = components.Button;
+	const fieldId = stringValue(field.id);
+	const fields = childFields(field);
+	const items = groupItems(value);
+	const label = stringValue(field.label || fieldId);
+	const description = stringValue(field.description);
+	const addItem = () => onChange([ ...items, defaultNestedValue(fields) ]);
+	const removeItem = (index) => onChange(items.filter((_, itemIndex) => itemIndex !== index));
+	const renderActionButton = (props, text) => typeof Button === 'function'
+		? createElement(Button, props, text)
+		: createElement('button', { ...props, type: 'button' }, text);
+
+	return createElement(
+		'div',
+		{
+			className: 'lerm-admin-config-block-panel__group',
+			role: 'group',
+		},
+		[
+			createElement('strong', { key: 'label' }, label),
+			description
+				? createElement('p', { className: 'lerm-admin-config-block-panel__field-description', key: 'description' }, description)
+				: null,
+			...items.map((item, index) => createElement(
+				'fieldset',
+				{
+					className: 'lerm-admin-config-block-panel__group-item',
+					key: `${ fieldId }-${ index }`,
+				},
+				[
+					createElement('legend', { key: 'legend' }, `Item ${ index + 1 }`),
+					...fields.map((child) => renderNestedField(
+						normalized,
+						child,
+						[ fieldId, String(index), stringValue(child.id) ],
+						childValue(child, item)
+					)),
+					renderActionButton(
+						{
+							key: 'remove',
+							onClick: () => removeItem(index),
+							variant: 'secondary',
+						},
+						'Remove item'
+					),
+				].filter(Boolean)
+			)),
+			renderActionButton(
+				{
+					key: 'add',
+					onClick: addItem,
+					variant: 'secondary',
+				},
+				'Add item'
+			),
+		].filter(Boolean)
+	);
+};
+
+/**
  * @param {ReturnType<typeof normalizeProps>} normalized
  * @returns {unknown}
  */
@@ -1229,7 +1629,10 @@ const createDefaultControlRegistry = () => createControlRegistry({
 	checkbox_list: CheckboxListControl,
 	color: ColorControl,
 	date: DateControl,
+	dimensions: DimensionsControl,
+	fieldset: FieldsetControl,
 	gallery: GalleryControl,
+	group: GroupControl,
 	media: MediaControl,
 	number: NumberControl,
 	radio: RadioControl,
@@ -1237,6 +1640,7 @@ const createDefaultControlRegistry = () => createControlRegistry({
 	slug_text: TextControl,
 	slider: RangeControl,
 	spinner: NumberControl,
+	spacing: SpacingControl,
 	switcher: ToggleControl,
 	text: TextControl,
 	textarea: TextareaControl,

--- a/packages/AdminConfig/resources/core/errors.js
+++ b/packages/AdminConfig/resources/core/errors.js
@@ -22,11 +22,12 @@ const normalizeErrorData = (responseData) => {
  */
 const fieldErrorsFromResponse = (responseData) => {
 	const data = normalizeErrorData(responseData);
-	const errors = data.fieldErrors || data.errors || {};
+	const errors = data.errors && typeof data.errors === 'object' ? data.errors : {};
+	const fieldErrors = data.fieldErrors && typeof data.fieldErrors === 'object' ? data.fieldErrors : {};
 
-	return errors && typeof errors === 'object'
-		? /** @type {Record<string, string|string[]>} */ (errors)
-		: {};
+	return /** @type {Record<string, string|string[]>} */ (
+		Object.keys(errors).length ? errors : fieldErrors
+	);
 };
 
 /**

--- a/packages/AdminConfig/resources/core/schema-state.js
+++ b/packages/AdminConfig/resources/core/schema-state.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 const { fieldErrorsFromResponse, messageFromResponse } = require('./errors');
-const { asRecord } = require('./records');
+const { asRecord, asRecordArray } = require('./records');
 
 /**
  * @typedef {{
@@ -170,11 +170,52 @@ const fieldControlType = (field) => {
 
 /**
  * @param {Record<string, unknown>} field
+ * @returns {Array<Record<string, unknown>>}
+ */
+const nestedFields = (field) => asRecordArray(field.fields);
+
+/**
+ * @param {Record<string, unknown>} field
+ * @param {Record<string, unknown>} value
+ * @returns {Record<string, unknown>}
+ */
+const serializeNestedRecord = (field, value) => {
+	const fields = nestedFields(field);
+
+	if (!fields.length) {
+		return value;
+	}
+
+	const payload = { ...value };
+
+	for (const child of fields) {
+		const childId = String(child.id || '');
+
+		if (!childId || !Object.prototype.hasOwnProperty.call(value, childId)) {
+			continue;
+		}
+
+		payload[childId] = serializeFieldValue(child, value[childId]);
+	}
+
+	return payload;
+};
+
+/**
+ * @param {Record<string, unknown>} field
  * @param {unknown} value
  * @returns {unknown}
  */
 const serializeFieldValue = (field, value) => {
 	switch (fieldControlType(field)) {
+		case 'fieldset':
+			return serializeNestedRecord(field, asRecord(value));
+
+		case 'group':
+			return Array.isArray(value)
+				? value.map((item) => serializeNestedRecord(field, asRecord(item)))
+				: [];
+
 		case 'media':
 			return { id: mediaAttachmentId(value) };
 

--- a/packages/AdminConfig/src/Client/SchemaSerializer.php
+++ b/packages/AdminConfig/src/Client/SchemaSerializer.php
@@ -33,9 +33,6 @@ final class SchemaSerializer {
 		'border',
 		'code_editor',
 		'content',
-		'dimensions',
-		'fieldset',
-		'group',
 		'heading',
 		'icon',
 		'image_select',
@@ -43,7 +40,6 @@ final class SchemaSerializer {
 		'notice',
 		'palette',
 		'sorter',
-		'spacing',
 		'subheading',
 		'tabbed',
 		'typography',
@@ -65,6 +61,29 @@ final class SchemaSerializer {
 		'rows',
 		'source',
 		'step',
+		'unit',
+	);
+
+	/**
+	 * @var array<int, string>
+	 */
+	private const FIELD_BOOLEAN_KEYS = array(
+		'all',
+		'bottom',
+		'height',
+		'left',
+		'right',
+		'show_units',
+		'top',
+		'width',
+	);
+
+	/**
+	 * @var array<int, string>
+	 */
+	private const FIELD_ARRAY_KEYS = array(
+		'fields',
+		'units',
 	);
 
 	/**
@@ -197,44 +216,104 @@ final class SchemaSerializer {
 		$fields    = array();
 
 		foreach ( $schema->field_metadata() as $field_id => $metadata ) {
-			$field_id = (string) $field_id;
-			$type     = sanitize_key( (string) ( $metadata['type'] ?? 'text' ) );
-			$client   = self::without_server_only_keys( isset( $metadata['client'] ) && is_array( $metadata['client'] ) ? $metadata['client'] : array() );
-			$control  = sanitize_key( (string) ( $client['control'] ?? $type ) );
-
-			if ( '' === $control ) {
-				$control = $type;
-			}
-
-			$field = array(
-				'id'          => $field_id,
-				'path'        => isset( $metadata['path'] ) && is_scalar( $metadata['path'] ) ? (string) $metadata['path'] : $field_id,
-				'type'        => '' !== $type ? $type : 'text',
-				'control'     => $control,
-				'label'       => isset( $metadata['label'] ) && is_scalar( $metadata['label'] ) ? (string) $metadata['label'] : '',
-				'description' => isset( $metadata['description'] ) && is_scalar( $metadata['description'] ) ? (string) $metadata['description'] : '',
-				'default'     => $metadata['default'] ?? null,
-				'section'     => $locations[ $field_id ]['section'] ?? '',
-				'group'       => $locations[ $field_id ]['group'] ?? '',
-				'choices'     => isset( $metadata['choices'] ) && is_array( $metadata['choices'] ) ? self::without_server_only_keys( $metadata['choices'] ) : array(),
-				'dependency'  => isset( $metadata['dependency'] ) && is_array( $metadata['dependency'] ) ? self::without_server_only_keys( $metadata['dependency'] ) : null,
-				'multiple'    => ! empty( $metadata['multiple'] ),
-				'readOnly'    => self::field_is_read_only( $control, $client ),
-				'supported'   => '' !== $control,
-				'ui'          => isset( $metadata['ui'] ) && is_array( $metadata['ui'] ) ? self::without_server_only_keys( $metadata['ui'] ) : array(),
-				'client'      => $client,
+			$field_id            = (string) $field_id;
+			$fields[ $field_id ] = self::field_payload(
+				$field_id,
+				$metadata,
+				$locations[ $field_id ] ?? array(
+					'section' => '',
+					'group'   => '',
+				)
 			);
-
-			foreach ( self::FIELD_SCALAR_KEYS as $key ) {
-				if ( isset( $metadata[ $key ] ) && is_scalar( $metadata[ $key ] ) ) {
-					$field[ $key ] = $metadata[ $key ];
-				}
-			}
-
-			$fields[ $field_id ] = $field;
 		}
 
 		return $fields;
+	}
+
+	/**
+	 * @param array<string, mixed> $metadata
+	 * @param array{section: string, group: string} $location
+	 * @return array<string, mixed>
+	 */
+	private static function field_payload( string $field_id, array $metadata, array $location ): array {
+		$type    = sanitize_key( (string) ( $metadata['type'] ?? 'text' ) );
+		$client  = self::without_server_only_keys( isset( $metadata['client'] ) && is_array( $metadata['client'] ) ? $metadata['client'] : array() );
+		$control = sanitize_key( (string) ( $client['control'] ?? $type ) );
+
+		if ( '' === $control ) {
+			$control = $type;
+		}
+
+		$field = array(
+			'id'          => $field_id,
+			'path'        => isset( $metadata['path'] ) && is_scalar( $metadata['path'] ) ? (string) $metadata['path'] : $field_id,
+			'type'        => '' !== $type ? $type : 'text',
+			'control'     => $control,
+			'label'       => isset( $metadata['label'] ) && is_scalar( $metadata['label'] ) ? (string) $metadata['label'] : '',
+			'description' => isset( $metadata['description'] ) && is_scalar( $metadata['description'] ) ? (string) $metadata['description'] : '',
+			'default'     => $metadata['default'] ?? null,
+			'section'     => $location['section'],
+			'group'       => $location['group'],
+			'choices'     => isset( $metadata['choices'] ) && is_array( $metadata['choices'] ) ? self::without_server_only_keys( $metadata['choices'] ) : array(),
+			'dependency'  => isset( $metadata['dependency'] ) && is_array( $metadata['dependency'] ) ? self::without_server_only_keys( $metadata['dependency'] ) : null,
+			'multiple'    => ! empty( $metadata['multiple'] ),
+			'readOnly'    => self::field_is_read_only( $control, $client ),
+			'supported'   => '' !== $control,
+			'ui'          => isset( $metadata['ui'] ) && is_array( $metadata['ui'] ) ? self::without_server_only_keys( $metadata['ui'] ) : array(),
+			'client'      => $client,
+		);
+
+		foreach ( self::FIELD_SCALAR_KEYS as $key ) {
+			if ( isset( $metadata[ $key ] ) && is_scalar( $metadata[ $key ] ) ) {
+				$field[ $key ] = $metadata[ $key ];
+			}
+		}
+
+		foreach ( self::FIELD_BOOLEAN_KEYS as $key ) {
+			if ( array_key_exists( $key, $metadata ) ) {
+				$field[ $key ] = (bool) $metadata[ $key ];
+			}
+		}
+
+		foreach ( self::FIELD_ARRAY_KEYS as $key ) {
+			if ( ! isset( $metadata[ $key ] ) || ! is_array( $metadata[ $key ] ) ) {
+				continue;
+			}
+
+			if ( 'fields' === $key ) {
+				$field[ $key ] = self::nested_fields( $metadata[ $key ] );
+				continue;
+			}
+
+			$field[ $key ] = self::without_server_only_keys( $metadata[ $key ] );
+		}
+
+		return $field;
+	}
+
+	/**
+	 * @param array<int, array<string, mixed>> $fields
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function nested_fields( array $fields ): array {
+		$nested = array();
+
+		foreach ( $fields as $field ) {
+			if ( ! is_array( $field ) || empty( $field['id'] ) || ! is_scalar( $field['id'] ) ) {
+				continue;
+			}
+
+			$nested[] = self::field_payload(
+				(string) $field['id'],
+				$field,
+				array(
+					'section' => '',
+					'group'   => '',
+				)
+			);
+		}
+
+		return $nested;
 	}
 
 	/**

--- a/packages/AdminConfig/src/Compiler/SchemaCompiler.php
+++ b/packages/AdminConfig/src/Compiler/SchemaCompiler.php
@@ -18,6 +18,45 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 final class SchemaCompiler {
 
+	/**
+	 * @var array<int, string>
+	 */
+	private const SCALAR_FIELD_PROPS = array(
+		'placeholder',
+		'input_type',
+		'min',
+		'max',
+		'step',
+		'rows',
+		'source',
+		'data_source',
+		'library',
+		'button_text',
+		'remove_text',
+		'unit',
+	);
+
+	/**
+	 * @var array<int, string>
+	 */
+	private const BOOLEAN_FIELD_PROPS = array(
+		'all',
+		'bottom',
+		'height',
+		'left',
+		'right',
+		'show_units',
+		'top',
+		'width',
+	);
+
+	/**
+	 * @var array<int, string>
+	 */
+	private const ARRAY_FIELD_PROPS = array(
+		'units',
+	);
+
 	public function __construct(
 		private ?FieldTypeRegistry $field_types = null
 	) {
@@ -41,7 +80,7 @@ final class SchemaCompiler {
 			}
 
 			$field_id                    = (string) $field['id'];
-			$field_metadata[ $field_id ] = $this->compile_field_metadata( $field );
+			$field_metadata[ $field_id ] = $this->compile_field_metadata( $field, $field_id );
 
 			if ( ! empty( $field_metadata[ $field_id ]['dependency'] ) ) {
 				$dependency_graph[ $field_id ] = $field_metadata[ $field_id ]['dependency'];
@@ -136,11 +175,14 @@ final class SchemaCompiler {
 	 * @param array<string, mixed> $field
 	 * @return array<string, mixed>
 	 */
-	private function compile_field_metadata( array $field ): array {
-		$type = sanitize_key( (string) ( $field['type'] ?? 'text' ) );
+	private function compile_field_metadata( array $field, string $path = '' ): array {
+		$type     = sanitize_key( (string) ( $field['type'] ?? 'text' ) );
+		$field_id = (string) $field['id'];
+		$path     = '' !== $path ? $path : $field_id;
 
 		$metadata = array(
-			'id'      => (string) $field['id'],
+			'id'      => $field_id,
+			'path'    => $path,
 			'type'    => $type,
 			'default' => $field['default'] ?? '',
 			'label'   => $this->first_string( $field, array( 'label' ) ),
@@ -167,11 +209,9 @@ final class SchemaCompiler {
 			$metadata['client'] = $client;
 		}
 
-		$this->copy_scalar_field_props(
-			$field,
-			$metadata,
-			array( 'placeholder', 'input_type', 'min', 'max', 'step', 'rows', 'source', 'data_source', 'library', 'button_text', 'remove_text' )
-		);
+		$this->copy_scalar_field_props( $field, $metadata, self::SCALAR_FIELD_PROPS );
+		$this->copy_boolean_field_props( $field, $metadata, self::BOOLEAN_FIELD_PROPS );
+		$this->copy_array_field_props( $field, $metadata, self::ARRAY_FIELD_PROPS );
 
 		foreach ( array( 'multiple' ) as $key ) {
 			if ( array_key_exists( $key, $field ) ) {
@@ -181,6 +221,11 @@ final class SchemaCompiler {
 
 		if ( array_key_exists( 'choices', $field ) ) {
 			$metadata['choices'] = PageSchema::choices( $field );
+		}
+
+		$nested_fields = $this->compile_nested_field_metadata( $field, $path, 'group' === $type );
+		if ( ! empty( $nested_fields ) ) {
+			$metadata['fields'] = $nested_fields;
 		}
 
 		$dependency = $this->compile_dependency( $field );
@@ -247,6 +292,53 @@ final class SchemaCompiler {
 				$metadata[ $key ] = $field[ $key ];
 			}
 		}
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 * @param array<string, mixed> $metadata
+	 * @param array<int, string>   $keys
+	 */
+	private function copy_boolean_field_props( array $field, array &$metadata, array $keys ): void {
+		foreach ( $keys as $key ) {
+			if ( array_key_exists( $key, $field ) ) {
+				$metadata[ $key ] = (bool) $field[ $key ];
+			}
+		}
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 * @param array<string, mixed> $metadata
+	 * @param array<int, string>   $keys
+	 */
+	private function copy_array_field_props( array $field, array &$metadata, array $keys ): void {
+		foreach ( $keys as $key ) {
+			if ( isset( $field[ $key ] ) && is_array( $field[ $key ] ) ) {
+				$metadata[ $key ] = $field[ $key ];
+			}
+		}
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function compile_nested_field_metadata( array $field, string $path, bool $is_group ): array {
+		$fields = is_array( $field['fields'] ?? null ) ? $field['fields'] : array();
+		$nested = array();
+
+		foreach ( $fields as $child ) {
+			if ( ! is_array( $child ) || empty( $child['id'] ) || ! is_scalar( $child['id'] ) ) {
+				continue;
+			}
+
+			$child_id   = (string) $child['id'];
+			$child_path = $is_group ? $path . '.*.' . $child_id : $path . '.' . $child_id;
+			$nested[]   = $this->compile_field_metadata( $child, $child_path );
+		}
+
+		return $nested;
 	}
 
 	/**

--- a/packages/AdminConfig/tests/E2E/block-editor-panel.spec.js
+++ b/packages/AdminConfig/tests/E2E/block-editor-panel.spec.js
@@ -182,8 +182,21 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	const entryUpload = panel.locator( '[data-field-id="entry_upload"]' );
 	const entryMedia = panel.locator( '[data-field-id="entry_media"]' );
 	const entryGallery = panel.locator( '[data-field-id="entry_gallery"]' );
+	const entryDimensions = panel.locator( '[data-field-id="entry_dimensions"]' );
+	const entrySpacing = panel.locator( '[data-field-id="entry_spacing"]' );
+	const entryLinks = panel.locator( '[data-field-id="entry_links"]' );
 	const entryIconReadOnly = panel.locator( '[data-field-id="entry_icon"][data-read-only-control="true"]' );
-	const entryBadgeReadOnly = panel.locator( '[data-field-id="entry_badge"][data-read-only-control="true"]' );
+	const entryBadge = panel.locator( '[data-field-id="entry_badge"]' );
+	const entryBadgeLabel = entryBadge.getByRole( 'textbox', { name: /^Label$/i } );
+	const entryBadgeSlug = entryBadge.getByRole( 'textbox', { name: /^Badge slug$/i } );
+	const entryDimensionsWidth = entryDimensions.getByRole( 'spinbutton', { name: /Entry card size Width/i } );
+	const entryDimensionsHeight = entryDimensions.getByRole( 'spinbutton', { name: /Entry card size Height/i } );
+	const entryDimensionsUnit = entryDimensions.getByRole( 'combobox', { name: /Entry card size unit/i } );
+	const entrySpacingTop = entrySpacing.getByRole( 'spinbutton', { name: /Entry card spacing Top/i } );
+	const entrySpacingRight = entrySpacing.getByRole( 'spinbutton', { name: /Entry card spacing Right/i } );
+	const entrySpacingUnit = entrySpacing.getByRole( 'combobox', { name: /Entry card spacing unit/i } );
+	const entryLinkLabel = entryLinks.getByRole( 'textbox', { name: /^Link label$/i } ).first();
+	const entryLinkUrl = entryLinks.getByRole( 'textbox', { name: /^Link URL$/i } ).first();
 	const newsletterChannel = panel.getByRole( 'checkbox', { name: /^Newsletter$/i } );
 
 	await expect( page.locator( '#lerm-admin-config-metabox-acme-demo-post-metabox' ) ).toHaveCount( 0 );
@@ -199,9 +212,16 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await expect( entryUpload.getByRole( 'button', { name: /^Choose uploaded file$/i } ) ).toBeVisible();
 	await expect( entryMedia.getByRole( 'button', { name: /^Choose image$/i } ) ).toBeVisible();
 	await expect( entryGallery.getByRole( 'button', { name: /^Choose gallery images$/i } ) ).toBeVisible();
+	await expect( entryBadgeLabel ).toBeVisible();
+	await expect( entryBadgeSlug ).toBeVisible();
+	await expect( entryDimensionsWidth ).toBeVisible();
+	await expect( entryDimensionsHeight ).toBeVisible();
+	await expect( entrySpacingTop ).toBeVisible();
+	await expect( entrySpacingRight ).toBeVisible();
+	await expect( entryLinkLabel ).toBeVisible();
+	await expect( entryLinkUrl ).toBeVisible();
 	await expect( newsletterChannel ).toBeVisible();
 	await expect( entryIconReadOnly ).toContainText( /Field type "icon" is read-only/i );
-	await expect( entryBadgeReadOnly ).toContainText( /Field type "fieldset" is read-only/i );
 	const initialChecked = await featuredToggle.isChecked();
 	const initialSlug = await entrySlug.inputValue();
 	const initialLayout = await entryLayout.inputValue();
@@ -211,6 +231,16 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	const initialReviewDate = await entryReviewDate.inputValue();
 	const initialPriority = await entryPriority.inputValue();
 	const initialScore = await entryScore.inputValue();
+	const initialBadgeLabel = await entryBadgeLabel.inputValue();
+	const initialBadgeSlug = await entryBadgeSlug.inputValue();
+	const initialDimensionsWidth = await entryDimensionsWidth.inputValue();
+	const initialDimensionsHeight = await entryDimensionsHeight.inputValue();
+	const initialDimensionsUnit = await entryDimensionsUnit.inputValue();
+	const initialSpacingTop = await entrySpacingTop.inputValue();
+	const initialSpacingRight = await entrySpacingRight.inputValue();
+	const initialSpacingUnit = await entrySpacingUnit.inputValue();
+	const initialLinkLabel = await entryLinkLabel.inputValue();
+	const initialLinkUrl = await entryLinkUrl.inputValue();
 	const initialNewsletter = await newsletterChannel.isChecked();
 	const discardSlug = initialSlug === 'discard-check' ? 'discard-check-next' : 'discard-check';
 	const discardLayout = initialLayout === 'wide' ? 'compact' : 'wide';
@@ -220,6 +250,16 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	const discardReviewDate = initialReviewDate === '2026-05-01' ? '2026-05-02' : '2026-05-01';
 	const discardPriority = initialPriority === '5' ? '4' : '5';
 	const discardScore = initialScore === '10' ? '9' : '10';
+	const discardBadgeLabel = initialBadgeLabel === 'Draft Badge' ? 'Draft Badge Next' : 'Draft Badge';
+	const discardBadgeSlug = initialBadgeSlug === 'draft-badge' ? 'draft-badge-next' : 'draft-badge';
+	const discardDimensionsWidth = initialDimensionsWidth === '480' ? '420' : '480';
+	const discardDimensionsHeight = initialDimensionsHeight === '260' ? '240' : '260';
+	const discardDimensionsUnit = initialDimensionsUnit === '%' ? 'px' : '%';
+	const discardSpacingTop = initialSpacingTop === '20' ? '18' : '20';
+	const discardSpacingRight = initialSpacingRight === '24' ? '22' : '24';
+	const discardSpacingUnit = initialSpacingUnit === 'rem' ? 'px' : 'rem';
+	const discardLinkLabel = initialLinkLabel === 'Discard Link' ? 'Discard Link Next' : 'Discard Link';
+	const discardLinkUrl = initialLinkUrl === 'https://example.test/discard' ? 'https://example.test/discard-next' : 'https://example.test/discard';
 	const savedSlug = initialSlug === 'block-panel-valid' ? 'block-panel-valid-next' : 'block-panel-valid';
 	const savedLayout = initialLayout === 'feature' ? 'compact' : 'feature';
 	const savedFormat = initialFormat === 'alert' ? 'editorial' : 'alert';
@@ -228,6 +268,16 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	const savedReviewDate = initialReviewDate === '2026-05-03' ? '2026-05-04' : '2026-05-03';
 	const savedPriority = initialPriority === '4' ? '3' : '4';
 	const savedScore = initialScore === '7' ? '6' : '7';
+	const savedBadgeLabel = initialBadgeLabel === 'Published Badge' ? 'Published Badge Next' : 'Published Badge';
+	const savedBadgeSlug = initialBadgeSlug === 'published-badge' ? 'published-badge-next' : 'published-badge';
+	const savedDimensionsWidth = initialDimensionsWidth === '640' ? '560' : '640';
+	const savedDimensionsHeight = initialDimensionsHeight === '360' ? '320' : '360';
+	const savedDimensionsUnit = initialDimensionsUnit === 'rem' ? 'px' : 'rem';
+	const savedSpacingTop = initialSpacingTop === '16' ? '14' : '16';
+	const savedSpacingRight = initialSpacingRight === '18' ? '14' : '18';
+	const savedSpacingUnit = initialSpacingUnit === 'rem' ? 'px' : 'rem';
+	const savedLinkLabel = initialLinkLabel === 'Continue reading' ? 'Read the update' : 'Continue reading';
+	const savedLinkUrl = initialLinkUrl === 'https://example.test/update' ? 'https://example.test/story' : 'https://example.test/update';
 
 	await entrySlug.fill( discardSlug );
 	await entryLayout.selectOption( discardLayout );
@@ -237,6 +287,16 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await setInputValue( entryReviewDate, discardReviewDate );
 	await setInputValue( entryPriority, discardPriority );
 	await entryScore.fill( discardScore );
+	await entryBadgeLabel.fill( discardBadgeLabel );
+	await entryBadgeSlug.fill( discardBadgeSlug );
+	await entryDimensionsWidth.fill( discardDimensionsWidth );
+	await entryDimensionsHeight.fill( discardDimensionsHeight );
+	await entryDimensionsUnit.selectOption( discardDimensionsUnit );
+	await entrySpacingTop.fill( discardSpacingTop );
+	await entrySpacingRight.fill( discardSpacingRight );
+	await entrySpacingUnit.selectOption( discardSpacingUnit );
+	await entryLinkLabel.fill( discardLinkLabel );
+	await entryLinkUrl.fill( discardLinkUrl );
 	await newsletterChannel.setChecked( ! initialNewsletter );
 	await expect( panel ).toHaveAttribute( 'data-dirty', 'true' );
 
@@ -257,6 +317,16 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await expect( entryReviewDate ).toHaveValue( initialReviewDate );
 	await expect( entryPriority ).toHaveValue( initialPriority );
 	await expect( entryScore ).toHaveValue( initialScore );
+	await expect( entryBadgeLabel ).toHaveValue( initialBadgeLabel );
+	await expect( entryBadgeSlug ).toHaveValue( initialBadgeSlug );
+	await expect( entryDimensionsWidth ).toHaveValue( initialDimensionsWidth );
+	await expect( entryDimensionsHeight ).toHaveValue( initialDimensionsHeight );
+	await expect( entryDimensionsUnit ).toHaveValue( initialDimensionsUnit );
+	await expect( entrySpacingTop ).toHaveValue( initialSpacingTop );
+	await expect( entrySpacingRight ).toHaveValue( initialSpacingRight );
+	await expect( entrySpacingUnit ).toHaveValue( initialSpacingUnit );
+	await expect( entryLinkLabel ).toHaveValue( initialLinkLabel );
+	await expect( entryLinkUrl ).toHaveValue( initialLinkUrl );
 	await expect( newsletterChannel ).toBeChecked( { checked: initialNewsletter } );
 
 	await entrySlug.fill( 'x' );
@@ -276,6 +346,24 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await entrySlug.fill( savedSlug );
 	await expect( panel ).toHaveAttribute( 'data-status', 'ready' );
 	await expect( panel ).toHaveAttribute( 'data-error-count', '0' );
+
+	await entryBadgeSlug.fill( 'x' );
+
+	const invalidNestedSaveRequest = page.waitForResponse( ( saveResponse ) => isMetaboxSaveResponse( saveResponse, 'acme-demo-post-metabox' ), { timeout: 20_000 } );
+
+	await panel.getByRole( 'button', { name: /^Save$/ } ).click();
+
+	const invalidNestedSaveResponse = await invalidNestedSaveRequest;
+
+	expect( invalidNestedSaveResponse.status() ).toBe( 422 );
+	await expect( panel ).toHaveAttribute( 'data-status', 'error' );
+	await expect( panel ).toHaveAttribute( 'data-error-count', '1' );
+	await expect( panel.locator( '[data-field-error="entry_badge.slug"]' ) ).toContainText( /between 3 and 32/i );
+
+	await entryBadgeSlug.fill( savedBadgeSlug );
+	await expect( panel ).toHaveAttribute( 'data-status', 'ready' );
+	await expect( panel ).toHaveAttribute( 'data-error-count', '0' );
+
 	await featuredToggle.setChecked( ! initialChecked );
 	await entryLayout.selectOption( savedLayout );
 	await entryFormat.locator( `input[type="radio"][value="${ savedFormat }"]` ).check();
@@ -284,6 +372,15 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await setInputValue( entryReviewDate, savedReviewDate );
 	await setInputValue( entryPriority, savedPriority );
 	await entryScore.fill( savedScore );
+	await entryBadgeLabel.fill( savedBadgeLabel );
+	await entryDimensionsWidth.fill( savedDimensionsWidth );
+	await entryDimensionsHeight.fill( savedDimensionsHeight );
+	await entryDimensionsUnit.selectOption( savedDimensionsUnit );
+	await entrySpacingTop.fill( savedSpacingTop );
+	await entrySpacingRight.fill( savedSpacingRight );
+	await entrySpacingUnit.selectOption( savedSpacingUnit );
+	await entryLinkLabel.fill( savedLinkLabel );
+	await entryLinkUrl.fill( savedLinkUrl );
 	await newsletterChannel.setChecked( ! initialNewsletter );
 	await selectMediaAttachments( page, entryUpload.getByRole( 'button', { name: /^Choose uploaded file$/i } ), [ 'Admin Config Media One' ] );
 	await selectMediaAttachments( page, entryMedia.getByRole( 'button', { name: /^Choose image$/i } ), [ 'Admin Config Media Two' ] );
@@ -316,6 +413,16 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await expect( entryReviewDate ).toHaveValue( savedReviewDate );
 	await expect( entryPriority ).toHaveValue( savedPriority );
 	await expect( entryScore ).toHaveValue( savedScore );
+	await expect( entryBadgeLabel ).toHaveValue( savedBadgeLabel );
+	await expect( entryBadgeSlug ).toHaveValue( savedBadgeSlug );
+	await expect( entryDimensionsWidth ).toHaveValue( savedDimensionsWidth );
+	await expect( entryDimensionsHeight ).toHaveValue( savedDimensionsHeight );
+	await expect( entryDimensionsUnit ).toHaveValue( savedDimensionsUnit );
+	await expect( entrySpacingTop ).toHaveValue( savedSpacingTop );
+	await expect( entrySpacingRight ).toHaveValue( savedSpacingRight );
+	await expect( entrySpacingUnit ).toHaveValue( savedSpacingUnit );
+	await expect( entryLinkLabel ).toHaveValue( savedLinkLabel );
+	await expect( entryLinkUrl ).toHaveValue( savedLinkUrl );
 	await expect( newsletterChannel ).toBeChecked( { checked: ! initialNewsletter } );
 	await expect( entryUpload.locator( '.lerm-admin-config-block-panel__media-url-preview img' ) ).toHaveAttribute( 'src', /admin-config-media-one/i );
 	await expect( entryMedia.locator( '.lerm-admin-config-block-panel__media-preview-item' ) ).toHaveCount( 1 );
@@ -339,6 +446,16 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await expect( reloadedPanel.locator( '[data-field-id="entry_review_date"] input[type="date"]' ) ).toHaveValue( savedReviewDate );
 	await expect( reloadedPanel.locator( '[data-field-id="entry_priority"] input[type="range"]' ) ).toHaveValue( savedPriority );
 	await expect( reloadedPanel.locator( '[data-field-id="entry_score"] input[type="number"]' ) ).toHaveValue( savedScore );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_badge"]' ).getByRole( 'textbox', { name: /^Label$/i } ) ).toHaveValue( savedBadgeLabel );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_badge"]' ).getByRole( 'textbox', { name: /^Badge slug$/i } ) ).toHaveValue( savedBadgeSlug );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_dimensions"]' ).getByRole( 'spinbutton', { name: /Entry card size Width/i } ) ).toHaveValue( savedDimensionsWidth );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_dimensions"]' ).getByRole( 'spinbutton', { name: /Entry card size Height/i } ) ).toHaveValue( savedDimensionsHeight );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_dimensions"]' ).getByRole( 'combobox', { name: /Entry card size unit/i } ) ).toHaveValue( savedDimensionsUnit );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_spacing"]' ).getByRole( 'spinbutton', { name: /Entry card spacing Top/i } ) ).toHaveValue( savedSpacingTop );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_spacing"]' ).getByRole( 'spinbutton', { name: /Entry card spacing Right/i } ) ).toHaveValue( savedSpacingRight );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_spacing"]' ).getByRole( 'combobox', { name: /Entry card spacing unit/i } ) ).toHaveValue( savedSpacingUnit );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_links"]' ).getByRole( 'textbox', { name: /^Link label$/i } ).first() ).toHaveValue( savedLinkLabel );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_links"]' ).getByRole( 'textbox', { name: /^Link URL$/i } ).first() ).toHaveValue( savedLinkUrl );
 	await expect( reloadedPanel.locator( '[data-field-id="entry_upload"] .lerm-admin-config-block-panel__media-url-preview img' ) ).toHaveAttribute( 'src', /admin-config-media-one/i );
 	await expect( reloadedPanel.locator( '[data-field-id="entry_media"] .lerm-admin-config-block-panel__media-preview-item' ) ).toHaveCount( 1 );
 	await expect( reloadedPanel.locator( '[data-field-id="entry_gallery"] .lerm-admin-config-block-panel__media-preview-item' ) ).toHaveCount( 2 );

--- a/packages/AdminConfig/tests/Unit/RestEndpointsTest.php
+++ b/packages/AdminConfig/tests/Unit/RestEndpointsTest.php
@@ -88,6 +88,11 @@ final class RestEndpointsTest extends TestCase {
 		$this->assertFalse( $data['fields']['site_title']['readOnly'] );
 		$this->assertTrue( $data['fields']['site_title']['supported'] );
 		$this->assertSame( 'campaigns', $data['fields']['campaign']['source'] );
+		$this->assertFalse( $data['fields']['badge']['readOnly'] );
+		$this->assertSame( 'badge.label', $data['fields']['badge']['fields'][0]['path'] );
+		$this->assertSame( 'text', $data['fields']['badge']['fields'][0]['control'] );
+		$this->assertFalse( $data['fields']['card_spacing']['readOnly'] );
+		$this->assertSame( array( 'px', 'rem' ), $data['fields']['card_spacing']['units'] );
 	}
 
 	public function testCanonicalSchemaIndexListsAccessibleSummaries(): void {
@@ -189,6 +194,16 @@ final class RestEndpointsTest extends TestCase {
 				'site_title'    => 'Updated title',
 				'items_per_row' => 4,
 				'campaign'      => '',
+				'badge'         => array(
+					'label' => '',
+				),
+				'card_spacing'  => array(
+					'unit'   => 'px',
+					'top'    => '8',
+					'right'  => '',
+					'bottom' => '',
+					'left'   => '',
+				),
 			),
 			$GLOBALS['lerm_admin_config_options']['rest_test_settings']
 		);
@@ -491,6 +506,16 @@ final class RestEndpointsTest extends TestCase {
 				'site_title'    => 'Default title',
 				'items_per_row' => 4,
 				'campaign'      => '',
+				'badge'         => array(
+					'label' => 'Featured',
+				),
+				'card_spacing'  => array(
+					'unit'   => 'px',
+					'top'    => '8',
+					'right'  => '',
+					'bottom' => '',
+					'left'   => '',
+				),
 			),
 			$response->get_data()['data']['values']
 		);
@@ -499,6 +524,16 @@ final class RestEndpointsTest extends TestCase {
 				'site_title'    => 'Default title',
 				'items_per_row' => 4,
 				'campaign'      => '',
+				'badge'         => array(
+					'label' => 'Featured',
+				),
+				'card_spacing'  => array(
+					'unit'   => 'px',
+					'top'    => '8',
+					'right'  => '',
+					'bottom' => '',
+					'left'   => '',
+				),
 			),
 			$GLOBALS['lerm_admin_config_options']['rest_test_settings']
 		);
@@ -669,6 +704,29 @@ final class RestEndpointsTest extends TestCase {
 								'type'    => 'ajax_select',
 								'source'  => 'campaigns',
 								'default' => '',
+							),
+							array(
+								'id'      => 'badge',
+								'type'    => 'fieldset',
+								'default' => array(
+									'label' => 'Featured',
+								),
+								'fields'  => array(
+									array(
+										'id'      => 'label',
+										'type'    => 'text',
+										'default' => 'Featured',
+									),
+								),
+							),
+							array(
+								'id'      => 'card_spacing',
+								'type'    => 'spacing',
+								'units'   => array( 'px', 'rem' ),
+								'default' => array(
+									'top'  => '8',
+									'unit' => 'px',
+								),
 							),
 						),
 					),

--- a/packages/AdminConfig/tests/Unit/SchemaCompilerTest.php
+++ b/packages/AdminConfig/tests/Unit/SchemaCompilerTest.php
@@ -138,6 +138,61 @@ final class SchemaCompilerTest extends TestCase {
 		$this->assertArrayNotHasKey( 'dependency', $compiled->client_config()['fields']['empty_controller'] );
 	}
 
+	public function testCompilesNestedFieldMetadataForStructuredControls(): void {
+		$compiled = ( new SchemaCompiler() )->compile(
+			array(
+				'id'       => 'structured_controls',
+				'sections' => array(
+					'general' => array(
+						'fields' => array(
+							array(
+								'id'      => 'badge',
+								'type'    => 'fieldset',
+								'fields'  => array(
+									array(
+										'id'      => 'label',
+										'type'    => 'text',
+										'default' => 'Featured',
+									),
+								),
+								'default' => array(
+									'label' => 'Featured',
+								),
+							),
+							array(
+								'id'      => 'links',
+								'type'    => 'group',
+								'fields'  => array(
+									array(
+										'id'   => 'url',
+										'type' => 'url',
+									),
+								),
+								'default' => array(),
+							),
+							array(
+								'id'    => 'spacing',
+								'type'  => 'spacing',
+								'units' => array( 'px', 'rem' ),
+								'top'   => true,
+								'left'  => false,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$fields = $compiled->client_config()['fields'];
+
+		$this->assertSame( 'badge.label', $fields['badge']['fields'][0]['path'] );
+		$this->assertSame( 'text', $fields['badge']['fields'][0]['client']['control'] ?? $fields['badge']['fields'][0]['type'] );
+		$this->assertSame( 'links.*.url', $fields['links']['fields'][0]['path'] );
+		$this->assertSame( array( 'px', 'rem' ), $fields['spacing']['units'] );
+		$this->assertTrue( $fields['spacing']['top'] );
+		$this->assertFalse( $fields['spacing']['left'] );
+	}
+
 	public function testDependencyDefaultsEmptyOperatorToEquality(): void {
 		$compiled = ( new SchemaCompiler() )->compile(
 			array(

--- a/packages/AdminConfig/tools/test-js-runtime.js
+++ b/packages/AdminConfig/tools/test-js-runtime.js
@@ -49,11 +49,14 @@ function testErrorHelpers() {
 			fieldErrors: {
 				title: 'Required.',
 			},
+			errors: {
+				'group.title': [ 'Nested required.' ],
+			},
 			message: 'Validation failed.',
 		},
 	};
 
-	assert.deepEqual(fieldErrorsFromResponse(response), { title: 'Required.' });
+	assert.deepEqual(fieldErrorsFromResponse(response), { 'group.title': [ 'Nested required.' ] });
 	assert.equal(messageFromResponse(response), 'Validation failed.');
 }
 
@@ -156,6 +159,20 @@ function testSchemaStateHelpers() {
 					control: 'gallery',
 					id: 'entry_gallery',
 				},
+				entry_group: {
+					control: 'group',
+					fields: [
+						{
+							control: 'media',
+							id: 'image',
+						},
+						{
+							control: 'text',
+							id: 'label',
+						},
+					],
+					id: 'entry_group',
+				},
 			},
 		},
 		{
@@ -168,6 +185,15 @@ function testSchemaStateHelpers() {
 				thumbnail: 'https://example.test/one-150x150.png',
 				url: 'https://example.test/one.png',
 			},
+			entry_group: [
+				{
+					image: {
+						id: 14,
+						url: 'https://example.test/group.png',
+					},
+					label: 'Group image',
+				},
+			],
 			entry_upload: 'https://example.test/upload.png',
 		}
 	);
@@ -199,6 +225,14 @@ function testSchemaStateHelpers() {
 			entry_media: {
 				id: 11,
 			},
+			entry_group: [
+				{
+					image: {
+						id: 14,
+					},
+					label: 'Group image',
+				},
+			],
 			entry_upload: 'https://example.test/upload.png',
 		},
 	});
@@ -223,10 +257,14 @@ function testDefaultControlRegistry() {
 	assert(types.includes('button_set'));
 	assert(types.includes('color'));
 	assert(types.includes('date'));
+	assert(types.includes('dimensions'));
+	assert(types.includes('fieldset'));
 	assert(types.includes('gallery'));
+	assert(types.includes('group'));
 	assert(types.includes('media'));
 	assert(types.includes('slider'));
 	assert(types.includes('spinner'));
+	assert(types.includes('spacing'));
 	assert(types.includes('upload'));
 
 	const rendered = registry.get('text')({
@@ -372,9 +410,6 @@ function testBlockPanelFieldStatusContract() {
 		'border',
 		'code_editor',
 		'content',
-		'dimensions',
-		'fieldset',
-		'group',
 		'heading',
 		'icon',
 		'image_select',
@@ -382,7 +417,6 @@ function testBlockPanelFieldStatusContract() {
 		'notice',
 		'palette',
 		'sorter',
-		'spacing',
 		'subheading',
 		'tabbed',
 		'typography',


### PR DESCRIPTION
## Summary
- Adds editable block editor panel controls for AdminConfig `fieldset`, `group`, `dimensions`, and `spacing` fields.
- Extends the client schema protocol with nested field metadata, dotted paths, design flags, and units.
- Serializes nested field values recursively through the REST save payload, including nested media values for future composite controls.
- Replays REST validation errors on dotted child paths and keeps metabox/post-meta fields in custom Panel UI rather than `InnerBlocks`.
- Extends demo schema, runtime checks, unit coverage, field matrix docs, and block editor E2E coverage.

## Validation
- `composer ci`
- `npm run check:phase2`
- `npm run test:e2e:block-editor`