### PR TITLE
[codex] Add AdminConfig async select panel control

### DIFF
--- a/packages/AdminConfig/CHANGELOG.md
+++ b/packages/AdminConfig/CHANGELOG.md
@@ -60,6 +60,9 @@ The format follows Keep a Changelog and the package uses Semantic Versioning onc
   values, REST serialization, and browser persistence coverage.
 - Block editor panel visual choice controls for `palette`, `image_select`, and
   `icon` fields, including discard/save/reload browser coverage.
+- Block editor panel async `ajax_select` controls backed by the REST
+  data-source endpoint, including selected-value hydration and browser
+  persistence coverage.
 
 ### Changed
 - The package is now documented as an open-source runtime with a clearer contributor onboarding path and explicit support expectations.

--- a/packages/AdminConfig/docs/block-editor-field-matrix.md
+++ b/packages/AdminConfig/docs/block-editor-field-matrix.md
@@ -54,6 +54,7 @@ features where values belong in block content rather than AdminConfig storage.
 | `palette` | Swatch-backed palette choice editing. |
 | `image_select` | Image-backed single choice editing. |
 | `icon` | Dashicons choice editing. |
+| `ajax_select` | REST data-source search and async single/multiple value editing. |
 
 ## Read-Only
 
@@ -62,7 +63,6 @@ features where values belong in block content rather than AdminConfig storage.
 | `heading`, `subheading`, `content`, `notice` | Presentation-only fields; no persisted value should enter the save payload. |
 | `accordion`, `tabbed`, `sorter` | Needs structured collection state and ordering semantics. |
 | `code_editor`, `wp_editor` | Needs editor-specific component integration and sanitization-aware UX. |
-| `ajax_select` | Needs REST data-source search, pagination, and async selection UX in the block panel. |
 | `backup_tools` | Options-page utility action; not suitable for block-panel editing. |
 
 ## Unsupported

--- a/packages/AdminConfig/examples/schema-demo-plugin/src/SchemaDemoPlugin.php
+++ b/packages/AdminConfig/examples/schema-demo-plugin/src/SchemaDemoPlugin.php
@@ -609,6 +609,18 @@ final class SchemaDemoPlugin {
 							'default'     => 'cover',
 						),
 						array(
+							'id'                => 'entry_campaign',
+							'type'              => 'ajax_select',
+							'source'            => 'campaign_library',
+							'label'             => __( 'Entry campaign', 'lerm-admin-config-demo' ),
+							'description'       => __( 'An async campaign selector rendered through the block editor panel REST data-source endpoint.', 'lerm-admin-config-demo' ),
+							'placeholder'       => __( 'Search campaigns...', 'lerm-admin-config-demo' ),
+							'search_label'      => __( 'Search entry campaign', 'lerm-admin-config-demo' ),
+							'min_search_length' => 1,
+							'per_page'          => 4,
+							'default'           => 'spring-launch',
+						),
+						array(
 							'id'          => 'entry_links',
 							'type'        => 'group',
 							'label'       => __( 'Entry links', 'lerm-admin-config-demo' ),

--- a/packages/AdminConfig/resources/block-panel/index.js
+++ b/packages/AdminConfig/resources/block-panel/index.js
@@ -22,7 +22,6 @@ const panelInstances = new Map();
 const registeredPanelNames = new Set();
 const READ_ONLY_CONTROL_TYPES = new Set([
 	'accordion',
-	'ajax_select',
 	'backup_tools',
 	'code_editor',
 	'content',
@@ -55,9 +54,33 @@ const createBlockPanelRuntime = (config = {}, options = {}) => {
 		return queryString ? `${path}?${queryString}` : path;
 	};
 
+	/**
+	 * @param {Record<string, unknown>} params
+	 * @returns {Promise<{ success: boolean, data: Record<string, unknown> }>}
+	 */
+	const requestDataSource = (params = {}) => {
+		const body = new FormData();
+		const selected = Array.isArray(params.selected) ? params.selected : [];
+
+		body.set('field_id', String(params.fieldId || ''));
+		body.set('search', String(params.search || ''));
+		body.set('page', String(params.page || 1));
+		body.set('per_page', String(params.perPage || 20));
+
+		selected.map(String).filter(Boolean).forEach((value) => {
+			body.append('selected[]', value);
+		});
+
+		return rest.request(withContext(`schemas/${ schemaId }/data-source`), {
+			body,
+			method: 'POST',
+		});
+	};
+
 	return {
 		controls,
 		rest,
+		requestDataSource,
 		storeName: STORE_NAME,
 
 		getContext: () => ({ ...context }),
@@ -567,6 +590,7 @@ const createPanelComponent = (config, Panel, element) => {
 								components,
 								controls: runtime.controls,
 								createElement,
+								dataSourceRequest: runtime.requestDataSource,
 								error,
 								errors: state.errors || {},
 								field,

--- a/packages/AdminConfig/resources/controls/index.js
+++ b/packages/AdminConfig/resources/controls/index.js
@@ -86,6 +86,44 @@ const choiceOptions = (field) => Object.entries(asRecord(field.choices)).map(([ 
 }));
 
 /**
+ * @param {Record<string, unknown>} item
+ * @returns {{ label: string, value: string }}
+ */
+const dataSourceOption = (item) => ({
+	label: stringValue(item.label || item.value),
+	value: stringValue(item.value),
+});
+
+/**
+ * @param {unknown} response
+ * @returns {Array<{ label: string, value: string }>}
+ */
+const dataSourceOptions = (response) => {
+	const data = asRecord(response);
+	const items = asArray(data.items);
+
+	return items.map(asRecord).map(dataSourceOption).filter((option) => option.value && option.label);
+};
+
+/**
+ * @param {Array<{ label: string, value: string }>} options
+ * @param {Array<{ label: string, value: string }>} selected
+ * @returns {Array<{ label: string, value: string }>}
+ */
+const mergeOptions = (options, selected = []) => {
+	const seen = new Set();
+	const merged = [];
+
+	for (const option of [ ...selected, ...options ]) {
+		if (!option.value || seen.has(option.value)) continue;
+		seen.add(option.value);
+		merged.push(option);
+	}
+
+	return merged;
+};
+
+/**
  * @param {unknown} error
  * @returns {string}
  */
@@ -99,6 +137,7 @@ const errorMessage = (error) => asArray(error).length
  *   components: Record<string, Function>,
  *   controls: { get: (type: string) => FieldControl|null },
  *   createElement: Function,
+ *   dataSourceRequest: Function,
  *   error: string,
  *   errors: Record<string, string|string[]>,
  *   field: Record<string, unknown>,
@@ -113,6 +152,7 @@ const normalizeProps = (props) => ({
 	components: /** @type {Record<string, Function>} */ (asRecord(props.components)),
 	controls: /** @type {{ get: (type: string) => FieldControl|null }} */ (props.controls || { get: () => null }),
 	createElement: /** @type {Function} */ (props.createElement),
+	dataSourceRequest: /** @type {Function} */ (props.dataSourceRequest || (() => Promise.resolve({ success: false, data: { message: 'Data-source transport is unavailable.' } }))),
 	error: errorMessage(props.error),
 	errors: /** @type {Record<string, string|string[]>} */ (asRecord(props.errors)),
 	field: asRecord(props.field),
@@ -240,7 +280,7 @@ const groupItems = (value) => Array.isArray(value) ? value.map(asRecord) : [];
  * @returns {unknown}
  */
 const renderNestedField = (normalized, field, path, value) => {
-	const { components, controls, createElement, errors, inputId, onPathChange } = normalized;
+	const { components, controls, createElement, dataSourceRequest, errors, inputId, onPathChange } = normalized;
 	const fieldId = stringValue(field.id);
 	const controlType = fieldControlType(field);
 	const control = controls.get(controlType);
@@ -289,6 +329,7 @@ const renderNestedField = (normalized, field, path, value) => {
 				components,
 				controls,
 				createElement,
+				dataSourceRequest,
 				error,
 				errors,
 				field,
@@ -1024,6 +1065,250 @@ const ColorControl = (props) => {
 };
 
 /**
+ * @param {ReturnType<typeof normalizeProps>} normalized
+ * @returns {unknown}
+ */
+const AjaxSelectControlComponent = (normalized) => {
+	const { components, createElement, dataSourceRequest, field, onChange, value } = normalized;
+	const element = typeof window !== 'undefined' && window.wp ? asRecord(window.wp.element) : {};
+	const useEffect = /** @type {Function|undefined} */ (element.useEffect);
+	const useState = /** @type {Function|undefined} */ (element.useState);
+	const Button = components.Button;
+	const Spinner = components.Spinner;
+	const fieldId = stringValue(field.id);
+	const multiple = field.multiple === true;
+	const allowClear = !Object.prototype.hasOwnProperty.call(field, 'allow_clear') || field.allow_clear !== false;
+	const minLength = ajaxMinSearchLength(field);
+	const perPage = ajaxPerPage(field);
+	const selectedValues = ajaxSelectedValues(value, field);
+	const selectedKey = selectedValues.join('\u0001');
+	const label = stringValue(field.label || fieldId);
+	const description = stringValue(field.description);
+	const placeholder = stringValue(field.placeholder || 'Search...');
+	const searchLabel = stringValue(field.search_label || `Search ${ label }`);
+	const renderButton = (props, content) => typeof Button === 'function'
+		? createElement(Button, props, content)
+		: createElement('button', { ...props, type: 'button' }, content);
+
+	if (typeof useState !== 'function' || typeof useEffect !== 'function') {
+		return createElement('p', { className: 'lerm-admin-config-block-panel__field-description' }, 'Async select requires the WordPress element runtime.');
+	}
+
+	const [ search, setSearch ] = useState('');
+	const [ options, setOptions ] = useState([]);
+	const [ selectedOptions, setSelectedOptions ] = useState(
+		() => selectedValues.map((item) => selectedOptionForValue(item, []))
+	);
+	const [ status, setStatus ] = useState(
+		minLength > 0 ? `Type ${ minLength } or more characters to search.` : 'Start typing to search.'
+	);
+	const [ isLoading, setIsLoading ] = useState(false);
+
+	useEffect(() => {
+		let active = true;
+
+		if (!selectedValues.length) {
+			setSelectedOptions([]);
+			return () => {
+				active = false;
+			};
+		}
+
+		dataSourceRequest({
+			fieldId,
+			page: 1,
+			perPage: Math.max(perPage, selectedValues.length),
+			search: '',
+			selected: selectedValues,
+		}).then((response) => {
+			if (!active) return;
+
+			const data = asRecord(response && response.data);
+			const fetchedOptions = response && response.success ? dataSourceOptions(data) : [];
+
+			setSelectedOptions(selectedValues.map((item) => selectedOptionForValue(item, fetchedOptions)));
+		});
+
+		return () => {
+			active = false;
+		};
+	}, [ fieldId, perPage, selectedKey ]);
+
+	useEffect(() => {
+		const term = stringValue(search).trim();
+		let active = true;
+
+		if (term.length < minLength) {
+			setOptions([]);
+			setIsLoading(false);
+			setStatus(minLength > 0 ? `Type ${ minLength } or more characters to search.` : 'Start typing to search.');
+			return () => {
+				active = false;
+			};
+		}
+
+		setIsLoading(true);
+		setStatus('Searching...');
+
+		const timer = setTimeout(() => {
+			dataSourceRequest({
+				fieldId,
+				page: 1,
+				perPage,
+				search: term,
+				selected: selectedValues,
+			}).then((response) => {
+				if (!active) return;
+
+				const data = asRecord(response && response.data);
+
+				if (!response || !response.success) {
+					setOptions([]);
+					setStatus(stringValue(data.message || 'Unable to load options.'));
+					return;
+				}
+
+				const nextOptions = dataSourceOptions(data);
+
+				setOptions(nextOptions);
+				setStatus(nextOptions.length ? 'Select an option.' : 'No options found.');
+			}).finally(() => {
+				if (active) setIsLoading(false);
+			});
+		}, 250);
+
+		return () => {
+			active = false;
+			clearTimeout(timer);
+		};
+	}, [ fieldId, minLength, perPage, search, selectedKey ]);
+
+	const selected = selectedValues.map((item) => selectedOptionForValue(item, selectedOptions));
+	const chooseOption = (option) => {
+		const nextSelectedOptions = mergeOptions([ option ], selectedOptions);
+
+		setSelectedOptions(nextSelectedOptions);
+
+		if (multiple) {
+			onChange(Array.from(new Set([ ...selectedValues, option.value ])));
+			return;
+		}
+
+		onChange(option.value);
+		setSearch('');
+		setOptions([]);
+	};
+	const removeValue = (item) => {
+		if (multiple) {
+			onChange(selectedValues.filter((candidate) => candidate !== item));
+			return;
+		}
+
+		onChange('');
+	};
+	const resultOptions = options.filter((option) => !multiple || !selectedValues.includes(option.value));
+
+	return createElement(
+		'fieldset',
+		{
+			className: 'lerm-admin-config-block-panel__ajax-select',
+		},
+		[
+			createElement('legend', { key: 'legend' }, label),
+			description
+				? createElement('p', { className: 'lerm-admin-config-block-panel__field-description', key: 'description' }, description)
+				: null,
+			createElement(
+				'div',
+				{
+					className: 'lerm-admin-config-block-panel__ajax-select-selected',
+					key: 'selected',
+				},
+				selected.length
+					? selected.map((option) => (
+						allowClear
+							? renderButton(
+								{
+									'data-selected-value': option.value,
+									key: option.value,
+									onClick: () => removeValue(option.value),
+									type: 'button',
+									variant: 'secondary',
+								},
+								`${ option.label } x`
+							)
+							: createElement('span', { 'data-selected-value': option.value, key: option.value }, option.label)
+					))
+					: createElement('span', { key: 'empty' }, 'No option selected.')
+			),
+			createElement(
+				'label',
+				{
+					className: 'lerm-admin-config-block-panel__ajax-select-search',
+					key: 'search',
+				},
+				[
+					createElement('span', { key: 'label' }, searchLabel),
+					createElement('input', {
+						'aria-label': searchLabel,
+						autoComplete: 'off',
+						key: 'input',
+						onInput: (event) => setSearch(stringValue(changeValue(event))),
+						placeholder,
+						type: 'search',
+						value: search,
+					}),
+				]
+			),
+			createElement(
+				'p',
+				{
+					className: 'lerm-admin-config-block-panel__ajax-select-status',
+					key: 'status',
+					role: 'status',
+				},
+				[
+					isLoading && typeof Spinner === 'function' ? createElement(Spinner, { key: 'spinner' }) : null,
+					createElement('span', { key: 'text' }, status),
+				].filter(Boolean)
+			),
+			resultOptions.length
+				? createElement(
+					'div',
+					{
+						className: 'lerm-admin-config-block-panel__ajax-select-results',
+						key: 'results',
+						role: 'listbox',
+					},
+					resultOptions.map((option) => renderButton(
+						{
+							'aria-selected': selectedValues.includes(option.value) ? 'true' : 'false',
+							'data-value': option.value,
+							key: option.value,
+							onClick: () => chooseOption(option),
+							role: 'option',
+							type: 'button',
+							variant: 'secondary',
+						},
+						option.label
+					))
+				)
+				: null,
+		].filter(Boolean)
+	);
+};
+
+/**
+ * @param {Record<string, unknown>} props
+ * @returns {unknown}
+ */
+const AjaxSelectControl = (props) => {
+	const normalized = normalizeProps(props);
+
+	return normalized.createElement(AjaxSelectControlComponent, normalized);
+};
+
+/**
  * @param {Record<string, unknown>} props
  * @returns {unknown}
  */
@@ -1647,6 +1932,44 @@ const imageSelectOptions = (field) => Object.entries(asRecord(field.choices))
 		value: stringValue(value),
 	}))
 	.filter((option) => option.value);
+
+/**
+ * @param {unknown} value
+ * @param {Record<string, unknown>} field
+ * @returns {string[]}
+ */
+const ajaxSelectedValues = (value, field) => field.multiple === true
+	? asArray(value).map(stringValue).filter(Boolean)
+	: [ stringValue(value) ].filter(Boolean);
+
+/**
+ * @param {Record<string, unknown>} field
+ * @returns {number}
+ */
+const ajaxPerPage = (field) => {
+	const perPage = Number.parseInt(stringValue(field.per_page || 20), 10);
+
+	return Number.isFinite(perPage) && perPage > 0 ? perPage : 20;
+};
+
+/**
+ * @param {Record<string, unknown>} field
+ * @returns {number}
+ */
+const ajaxMinSearchLength = (field) => {
+	const minLength = Number.parseInt(stringValue(field.min_search_length || 0), 10);
+
+	return Number.isFinite(minLength) && minLength > 0 ? minLength : 0;
+};
+
+/**
+ * @param {string} value
+ * @param {Array<{ label: string, value: string }>} options
+ * @returns {{ label: string, value: string }}
+ */
+const selectedOptionForValue = (value, options) => (
+	options.find((option) => option.value === value) || { label: value, value }
+);
 
 /**
  * @param {Record<string, unknown>} field
@@ -2493,6 +2816,7 @@ const createControlRegistry = (initialControls = {}) => {
  * @returns {ReturnType<typeof createControlRegistry>}
  */
 const createDefaultControlRegistry = () => createControlRegistry({
+	ajax_select: AjaxSelectControl,
 	background: BackgroundControl,
 	button_set: ButtonSetControl,
 	border: BorderControl,

--- a/packages/AdminConfig/src/Client/SchemaSerializer.php
+++ b/packages/AdminConfig/src/Client/SchemaSerializer.php
@@ -27,7 +27,6 @@ final class SchemaSerializer {
 	 */
 	private const READ_ONLY_CONTROLS = array(
 		'accordion',
-		'ajax_select',
 		'backup_tools',
 		'code_editor',
 		'content',
@@ -53,9 +52,12 @@ final class SchemaSerializer {
 		'line_height_placeholder',
 		'max',
 		'min',
+		'min_search_length',
+		'per_page',
 		'placeholder',
 		'remove_text',
 		'rows',
+		'search_label',
 		'size_placeholder',
 		'source',
 		'step',
@@ -68,6 +70,7 @@ final class SchemaSerializer {
 	private const FIELD_BOOLEAN_KEYS = array(
 		'all',
 		'active',
+		'allow_clear',
 		'align',
 		'background_attachment',
 		'background_blend_mode',

--- a/packages/AdminConfig/src/Compiler/SchemaCompiler.php
+++ b/packages/AdminConfig/src/Compiler/SchemaCompiler.php
@@ -24,8 +24,11 @@ final class SchemaCompiler {
 	private const SCALAR_FIELD_PROPS = array(
 		'placeholder',
 		'input_type',
+		'min_search_length',
 		'min',
 		'max',
+		'per_page',
+		'search_label',
 		'step',
 		'rows',
 		'source',
@@ -47,6 +50,7 @@ final class SchemaCompiler {
 	private const BOOLEAN_FIELD_PROPS = array(
 		'all',
 		'active',
+		'allow_clear',
 		'align',
 		'background_attachment',
 		'background_blend_mode',

--- a/packages/AdminConfig/tests/E2E/block-editor-panel.spec.js
+++ b/packages/AdminConfig/tests/E2E/block-editor-panel.spec.js
@@ -41,6 +41,18 @@ const isMetaboxSaveResponse = ( response, schemaId ) => {
 	);
 };
 
+const isMetaboxDataSourceResponse = ( response, schemaId = 'acme-demo-post-metabox' ) => {
+	const url = decodedUrl( response );
+
+	return (
+		response.request().method() === 'POST' &&
+		(
+			url.includes( `/wp-json/lerm-admin-config/v1/schemas/${ schemaId }/data-source` ) ||
+			url.includes( `rest_route=/lerm-admin-config/v1/schemas/${ schemaId }/data-source` )
+		)
+	);
+};
+
 const escapeRegExp = ( value ) => value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
 
 const expandBlockPanel = async ( page, schemaId, title ) => {
@@ -121,6 +133,22 @@ const selectMediaAttachments = async ( page, trigger, titles ) => {
 	await expect( modal ).toBeHidden( { timeout: 20_000 } );
 };
 
+const selectAjaxOption = async ( page, field, search, value, label ) => {
+	const input = field.getByRole( 'searchbox', { name: /Search entry campaign/i } );
+	const responsePromise = page.waitForResponse(
+		( response ) => isMetaboxDataSourceResponse( response ),
+		{ timeout: 20_000 }
+	);
+
+	await input.fill( search );
+
+	const response = await responsePromise;
+
+	expect( response.ok() ).toBe( true );
+	await expect( field.locator( `button[data-value="${ value }"]` ) ).toContainText( label, { timeout: 20_000 } );
+	await field.locator( `button[data-value="${ value }"]` ).click();
+};
+
 test.skip(
 	process.env.LERM_ADMIN_CONFIG_BLOCK_EDITOR !== '1',
 	'Block editor smoke runs through npm run test:e2e:block-editor so the fixture can temporarily enable the editor.'
@@ -195,6 +223,7 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	const entryBackground = panel.locator( '[data-field-id="entry_background"]' );
 	const entryPalette = panel.locator( '[data-field-id="entry_palette"]' );
 	const entryImageStyle = panel.locator( '[data-field-id="entry_image_style"]' );
+	const entryCampaign = panel.locator( '[data-field-id="entry_campaign"]' );
 	const entryLinks = panel.locator( '[data-field-id="entry_links"]' );
 	const entryIcon = panel.locator( '[data-field-id="entry_icon"]' );
 	const entryBadge = panel.locator( '[data-field-id="entry_badge"]' );
@@ -238,6 +267,7 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	const entryPaletteWarm = entryPalette.locator( 'button[data-value="warm"]' );
 	const entryImageCover = entryImageStyle.locator( 'button[data-value="cover"]' );
 	const entryImageSplit = entryImageStyle.locator( 'button[data-value="split"]' );
+	const entryCampaignSearch = entryCampaign.getByRole( 'searchbox', { name: /Search entry campaign/i } );
 	const entryIconAside = entryIcon.locator( 'button[data-value="dashicons-format-aside"]' );
 	const entryIconAnnouncement = entryIcon.locator( 'button[data-value="dashicons-megaphone"]' );
 	const entryLinkLabel = entryLinks.getByRole( 'textbox', { name: /^Link label$/i } ).first();
@@ -293,6 +323,8 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await expect( entryPaletteWarm ).toBeVisible();
 	await expect( entryImageCover ).toBeVisible();
 	await expect( entryImageSplit ).toBeVisible();
+	await expect( entryCampaignSearch ).toBeVisible();
+	await expect( entryCampaign.locator( '[data-selected-value="spring-launch"]' ) ).toContainText( /Spring Launch|spring-launch/i );
 	await expect( entryIconAside ).toBeVisible();
 	await expect( entryIconAnnouncement ).toBeVisible();
 	await expect( entryLinkLabel ).toBeVisible();
@@ -342,6 +374,7 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	const initialBackgroundBlendMode = await entryBackgroundBlendMode.inputValue();
 	const initialPalette = await entryPalette.locator( 'button[aria-pressed="true"]' ).getAttribute( 'data-value' );
 	const initialImageStyle = await entryImageStyle.locator( 'button[aria-pressed="true"]' ).getAttribute( 'data-value' );
+	const initialCampaign = await entryCampaign.locator( '[data-selected-value]' ).first().getAttribute( 'data-selected-value' );
 	const initialIcon = await entryIcon.locator( 'button[aria-pressed="true"]' ).getAttribute( 'data-value' );
 	const initialLinkLabel = await entryLinkLabel.inputValue();
 	const initialLinkUrl = await entryLinkUrl.inputValue();
@@ -389,6 +422,9 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	const discardBackgroundBlendMode = initialBackgroundBlendMode === 'screen' ? 'overlay' : 'screen';
 	const discardPalette = initialPalette === 'warm' ? 'cool' : 'warm';
 	const discardImageStyle = initialImageStyle === 'split' ? 'cover' : 'split';
+	const discardCampaign = initialCampaign === 'studio-preview' ? 'design-sprint' : 'studio-preview';
+	const discardCampaignSearch = discardCampaign === 'studio-preview' ? 'studio' : 'design';
+	const discardCampaignLabel = discardCampaign === 'studio-preview' ? 'Studio Preview' : 'Design Sprint';
 	const discardIcon = initialIcon === 'dashicons-star-filled' ? 'dashicons-format-aside' : 'dashicons-star-filled';
 	const discardLinkLabel = initialLinkLabel === 'Discard Link' ? 'Discard Link Next' : 'Discard Link';
 	const discardLinkUrl = initialLinkUrl === 'https://example.test/discard' ? 'https://example.test/discard-next' : 'https://example.test/discard';
@@ -435,6 +471,9 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	const savedBackgroundBlendMode = initialBackgroundBlendMode === 'multiply' ? 'normal' : 'multiply';
 	const savedPalette = initialPalette === 'mono' ? 'cool' : 'mono';
 	const savedImageStyle = initialImageStyle === 'poster' ? 'cover' : 'poster';
+	const savedCampaign = initialCampaign === 'pro-tools' ? 'community-notes' : 'pro-tools';
+	const savedCampaignSearch = savedCampaign === 'pro-tools' ? 'pro' : 'community';
+	const savedCampaignLabel = savedCampaign === 'pro-tools' ? 'Pro Tools' : 'Community Notes';
 	const savedIcon = initialIcon === 'dashicons-megaphone' ? 'dashicons-format-aside' : 'dashicons-megaphone';
 	const savedLinkLabel = initialLinkLabel === 'Continue reading' ? 'Read the update' : 'Continue reading';
 	const savedLinkUrl = initialLinkUrl === 'https://example.test/update' ? 'https://example.test/story' : 'https://example.test/update';
@@ -482,6 +521,7 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await entryBackgroundBlendMode.selectOption( discardBackgroundBlendMode );
 	await entryPalette.locator( `button[data-value="${ discardPalette }"]` ).click();
 	await entryImageStyle.locator( `button[data-value="${ discardImageStyle }"]` ).click();
+	await selectAjaxOption( page, entryCampaign, discardCampaignSearch, discardCampaign, discardCampaignLabel );
 	await entryIcon.locator( `button[data-value="${ discardIcon }"]` ).click();
 	await entryLinkLabel.fill( discardLinkLabel );
 	await entryLinkUrl.fill( discardLinkUrl );
@@ -540,6 +580,7 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await expect( entryBackgroundBlendMode ).toHaveValue( initialBackgroundBlendMode );
 	await expect( entryPalette.locator( 'button[aria-pressed="true"]' ) ).toHaveAttribute( 'data-value', initialPalette || '' );
 	await expect( entryImageStyle.locator( 'button[aria-pressed="true"]' ) ).toHaveAttribute( 'data-value', initialImageStyle || '' );
+	await expect( entryCampaign.locator( '[data-selected-value]' ).first() ).toHaveAttribute( 'data-selected-value', initialCampaign || '' );
 	await expect( entryIcon.locator( 'button[aria-pressed="true"]' ) ).toHaveAttribute( 'data-value', initialIcon || '' );
 	await expect( entryLinkLabel ).toHaveValue( initialLinkLabel );
 	await expect( entryLinkUrl ).toHaveValue( initialLinkUrl );
@@ -622,6 +663,7 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await entryBackgroundBlendMode.selectOption( savedBackgroundBlendMode );
 	await entryPalette.locator( `button[data-value="${ savedPalette }"]` ).click();
 	await entryImageStyle.locator( `button[data-value="${ savedImageStyle }"]` ).click();
+	await selectAjaxOption( page, entryCampaign, savedCampaignSearch, savedCampaign, savedCampaignLabel );
 	await entryIcon.locator( `button[data-value="${ savedIcon }"]` ).click();
 	await entryLinkLabel.fill( savedLinkLabel );
 	await entryLinkUrl.fill( savedLinkUrl );
@@ -694,6 +736,7 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await expect( entryBackgroundBlendMode ).toHaveValue( savedBackgroundBlendMode );
 	await expect( entryPalette.locator( 'button[aria-pressed="true"]' ) ).toHaveAttribute( 'data-value', savedPalette );
 	await expect( entryImageStyle.locator( 'button[aria-pressed="true"]' ) ).toHaveAttribute( 'data-value', savedImageStyle );
+	await expect( entryCampaign.locator( '[data-selected-value]' ).first() ).toHaveAttribute( 'data-selected-value', savedCampaign );
 	await expect( entryIcon.locator( 'button[aria-pressed="true"]' ) ).toHaveAttribute( 'data-value', savedIcon );
 	await expect( entryLinkLabel ).toHaveValue( savedLinkLabel );
 	await expect( entryLinkUrl ).toHaveValue( savedLinkUrl );
@@ -756,6 +799,7 @@ test( 'block editor edits and saves AdminConfig panel values through REST', asyn
 	await expect( reloadedPanel.locator( '[data-field-id="entry_background"] [data-field-path="entry_background.background-blend-mode"] select' ) ).toHaveValue( savedBackgroundBlendMode );
 	await expect( reloadedPanel.locator( '[data-field-id="entry_palette"] button[aria-pressed="true"]' ) ).toHaveAttribute( 'data-value', savedPalette );
 	await expect( reloadedPanel.locator( '[data-field-id="entry_image_style"] button[aria-pressed="true"]' ) ).toHaveAttribute( 'data-value', savedImageStyle );
+	await expect( reloadedPanel.locator( '[data-field-id="entry_campaign"] [data-selected-value]' ).first() ).toHaveAttribute( 'data-selected-value', savedCampaign );
 	await expect( reloadedPanel.locator( '[data-field-id="entry_icon"] button[aria-pressed="true"]' ) ).toHaveAttribute( 'data-value', savedIcon );
 	await expect( reloadedPanel.locator( '[data-field-id="entry_links"]' ).getByRole( 'textbox', { name: /^Link label$/i } ).first() ).toHaveValue( savedLinkLabel );
 	await expect( reloadedPanel.locator( '[data-field-id="entry_links"]' ).getByRole( 'textbox', { name: /^Link URL$/i } ).first() ).toHaveValue( savedLinkUrl );

--- a/packages/AdminConfig/tests/Unit/RestEndpointsTest.php
+++ b/packages/AdminConfig/tests/Unit/RestEndpointsTest.php
@@ -88,6 +88,11 @@ final class RestEndpointsTest extends TestCase {
 		$this->assertFalse( $data['fields']['site_title']['readOnly'] );
 		$this->assertTrue( $data['fields']['site_title']['supported'] );
 		$this->assertSame( 'campaigns', $data['fields']['campaign']['source'] );
+		$this->assertFalse( $data['fields']['campaign']['readOnly'] );
+		$this->assertSame( 2, $data['fields']['campaign']['min_search_length'] );
+		$this->assertSame( 4, $data['fields']['campaign']['per_page'] );
+		$this->assertSame( 'Search campaigns', $data['fields']['campaign']['search_label'] );
+		$this->assertTrue( $data['fields']['campaign']['allow_clear'] );
 		$this->assertFalse( $data['fields']['badge']['readOnly'] );
 		$this->assertSame( 'badge.label', $data['fields']['badge']['fields'][0]['path'] );
 		$this->assertSame( 'text', $data['fields']['badge']['fields'][0]['control'] );
@@ -836,10 +841,14 @@ final class RestEndpointsTest extends TestCase {
 								'max'     => 6,
 							),
 							array(
-								'id'      => 'campaign',
-								'type'    => 'ajax_select',
-								'source'  => 'campaigns',
-								'default' => '',
+								'id'                => 'campaign',
+								'type'              => 'ajax_select',
+								'source'            => 'campaigns',
+								'allow_clear'       => true,
+								'min_search_length' => 2,
+								'per_page'          => 4,
+								'search_label'      => 'Search campaigns',
+								'default'           => '',
 							),
 							array(
 								'id'      => 'badge',

--- a/packages/AdminConfig/tests/Unit/SchemaCompilerTest.php
+++ b/packages/AdminConfig/tests/Unit/SchemaCompilerTest.php
@@ -228,6 +228,16 @@ final class SchemaCompilerTest extends TestCase {
 									'dashicons-lightbulb' => 'Idea',
 								),
 							),
+							array(
+								'id'                => 'campaign',
+								'type'              => 'ajax_select',
+								'source'            => 'campaigns',
+								'multiple'          => true,
+								'allow_clear'       => false,
+								'min_search_length' => 2,
+								'per_page'          => 7,
+								'search_label'      => 'Search campaigns',
+							),
 						),
 					),
 				),
@@ -259,6 +269,12 @@ final class SchemaCompilerTest extends TestCase {
 		$this->assertArrayNotHasKey( 'invalid', $fields['palette']['choices'] );
 		$this->assertSame( 'https://example.test/cover.png', $fields['image_style']['choices']['cover'] );
 		$this->assertSame( 'Idea', $fields['icon']['choices']['dashicons-lightbulb'] );
+		$this->assertSame( 'campaigns', $fields['campaign']['source'] );
+		$this->assertTrue( $fields['campaign']['multiple'] );
+		$this->assertFalse( $fields['campaign']['allow_clear'] );
+		$this->assertSame( 2, $fields['campaign']['min_search_length'] );
+		$this->assertSame( 7, $fields['campaign']['per_page'] );
+		$this->assertSame( 'Search campaigns', $fields['campaign']['search_label'] );
 	}
 
 	public function testDependencyDefaultsEmptyOperatorToEquality(): void {

--- a/packages/AdminConfig/tools/test-js-runtime.js
+++ b/packages/AdminConfig/tools/test-js-runtime.js
@@ -291,6 +291,7 @@ function testDefaultControlRegistry() {
 	const types = registry.types();
 
 	assert(types.includes('background'));
+	assert(types.includes('ajax_select'));
 	assert(types.includes('text'));
 	assert(types.includes('textarea'));
 	assert(types.includes('border'));
@@ -484,6 +485,20 @@ function testDefaultControlRegistry() {
 		onChange: (value) => changes.push(value),
 		value: 'dashicons-format-aside',
 	});
+	const renderedAjaxSelect = registry.get('ajax_select')({
+		components: {},
+		createElement: (type, props, ...children) => ({ type, props, children }),
+		dataSourceRequest: () => Promise.resolve({ success: true, data: { items: [] } }),
+		field: {
+			id: 'campaign',
+			label: 'Campaign',
+			source: 'campaign_library',
+			type: 'ajax_select',
+		},
+		inputId: 'demo-campaign',
+		onChange: (value) => changes.push(value),
+		value: 'spring-launch',
+	});
 
 	renderedSelect.props.onChange({ target: { value: 'feature' } });
 	renderedColor.children[0][1].props.onInput({ target: { value: '#13579b' } });
@@ -506,6 +521,7 @@ function testDefaultControlRegistry() {
 	assert.equal(renderedColor.children[0][1].props.onChange, undefined);
 	assert.equal(renderedDate.children[0][1].props.onChange, undefined);
 	assert.equal(renderedRange.children[0][1].props.onChange, undefined);
+	assert.equal(typeof renderedAjaxSelect.type, 'function');
 }
 
 function testBlockPanelFieldStatusContract() {
@@ -514,7 +530,6 @@ function testBlockPanelFieldStatusContract() {
 
 	for (const type of [
 		'accordion',
-		'ajax_select',
 		'backup_tools',
 		'code_editor',
 		'content',


### PR DESCRIPTION
## Summary
- Move AdminConfig `ajax_select` from block-panel read-only to editable.
- Add a REST data-source request bridge plus async search/selection control for the block editor panel.
- Extend schema protocol metadata, demo schema, runtime/unit coverage, and block editor persistence coverage.

## Validation
- `composer ci`
- `npm run check:phase2`
- `npm run test:e2e:block-editor`

## Stacked PR
- Base branch is `codex/adminconfig-visual-choice-panel-fields` until #50 lands.
