### PR TITLE
[codex] Simplify AdminConfig admin asset plumbing

### DIFF
--- a/packages/AdminConfig/CHANGELOG.md
+++ b/packages/AdminConfig/CHANGELOG.md
@@ -78,6 +78,9 @@ The format follows Keep a Changelog and the package uses Semantic Versioning onc
   scripts; `test:wp:rest-only` remains a temporary alias for
   `test:wp:rest-contract`.
 - The Ajax retirement plan now has documented `0.3.0` removal criteria and deletion candidates.
+- Admin asset localization, asset file path resolution, and schema field
+  metadata copying now use smaller shared helpers instead of page-local
+  duplicate logic.
 - The block editor field matrix now separates Phase 4 collection fields from
   read-only fields and is checked against JS/PHP field contracts.
 - Admin pages now prefer the built `assets/build/admin-config.js` bundle while retaining a packaged browser-file fallback for source checkouts.

--- a/packages/AdminConfig/src/Compiler/SchemaCompiler.php
+++ b/packages/AdminConfig/src/Compiler/SchemaCompiler.php
@@ -73,6 +73,7 @@ final class SchemaCompiler {
 		'letter_spacing',
 		'line_height',
 		'left',
+		'multiple',
 		'right',
 		'show_units',
 		'size',
@@ -243,15 +244,9 @@ final class SchemaCompiler {
 			$metadata['client'] = $client;
 		}
 
-		$this->copy_scalar_field_props( $field, $metadata, self::SCALAR_FIELD_PROPS );
-		$this->copy_boolean_field_props( $field, $metadata, self::BOOLEAN_FIELD_PROPS );
-		$this->copy_array_field_props( $field, $metadata, self::ARRAY_FIELD_PROPS );
-
-		foreach ( array( 'multiple' ) as $key ) {
-			if ( array_key_exists( $key, $field ) ) {
-				$metadata[ $key ] = (bool) $field[ $key ];
-			}
-		}
+		$this->copy_field_props( $field, $metadata, self::SCALAR_FIELD_PROPS, 'scalar' );
+		$this->copy_field_props( $field, $metadata, self::BOOLEAN_FIELD_PROPS, 'boolean' );
+		$this->copy_field_props( $field, $metadata, self::ARRAY_FIELD_PROPS, 'array' );
 
 		if ( 'palette' === $type ) {
 			$metadata['choices'] = $this->compile_palette_choices( $field );
@@ -362,35 +357,19 @@ final class SchemaCompiler {
 	 * @param array<string, mixed> $metadata
 	 * @param array<int, string>   $keys
 	 */
-	private function copy_scalar_field_props( array $field, array &$metadata, array $keys ): void {
+	private function copy_field_props( array $field, array &$metadata, array $keys, string $type ): void {
 		foreach ( $keys as $key ) {
-			if ( isset( $field[ $key ] ) && is_scalar( $field[ $key ] ) ) {
-				$metadata[ $key ] = $field[ $key ];
-			}
-		}
-	}
-
-	/**
-	 * @param array<string, mixed> $field
-	 * @param array<string, mixed> $metadata
-	 * @param array<int, string>   $keys
-	 */
-	private function copy_boolean_field_props( array $field, array &$metadata, array $keys ): void {
-		foreach ( $keys as $key ) {
-			if ( array_key_exists( $key, $field ) ) {
+			if ( 'boolean' === $type && array_key_exists( $key, $field ) ) {
 				$metadata[ $key ] = (bool) $field[ $key ];
+				continue;
 			}
-		}
-	}
 
-	/**
-	 * @param array<string, mixed> $field
-	 * @param array<string, mixed> $metadata
-	 * @param array<int, string>   $keys
-	 */
-	private function copy_array_field_props( array $field, array &$metadata, array $keys ): void {
-		foreach ( $keys as $key ) {
-			if ( isset( $field[ $key ] ) && is_array( $field[ $key ] ) ) {
+			if ( 'array' === $type && isset( $field[ $key ] ) && is_array( $field[ $key ] ) ) {
+				$metadata[ $key ] = $field[ $key ];
+				continue;
+			}
+
+			if ( 'scalar' === $type && isset( $field[ $key ] ) && is_scalar( $field[ $key ] ) ) {
 				$metadata[ $key ] = $field[ $key ];
 			}
 		}

--- a/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
+++ b/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
@@ -11,7 +11,10 @@ namespace Lerm\AdminConfig\Framework\Admin;
 
 use Lerm\AdminConfig\Framework\FieldTypes\FieldTypeRegistry;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
+use Lerm\AdminConfig\Framework\Contracts\AssetPathResolver;
 use Lerm\AdminConfig\Framework\Contracts\AssetResolver;
+use Lerm\AdminConfig\Framework\Support\I18nStrings;
+use Lerm\AdminConfig\Framework\Support\PackageAssets;
 use Lerm\AdminConfig\Framework\Support\PageSchema;
 use Lerm\AdminConfig\Registry\FieldModuleRegistry;
 
@@ -218,55 +221,7 @@ final class OptionsPage {
 		wp_localize_script(
 			$js_handle,
 			$this->js_global,
-			array(
-				'restUrl'             => rest_url( 'lerm-admin-config/v1/' ),
-				'restNonce'           => wp_create_nonce( 'wp_rest' ),
-				'codeEditor'          => $code_editor_settings,
-				'selectMedia'         => __( 'Choose image', 'lerm' ),
-				'useMedia'            => __( 'Use this image', 'lerm' ),
-				'selectFile'          => __( 'Choose file', 'lerm' ),
-				'useFile'             => __( 'Use this file', 'lerm' ),
-				'selectImages'        => __( 'Choose images', 'lerm' ),
-				'useImages'           => __( 'Use these images', 'lerm' ),
-				'removeMedia'         => __( 'Remove image', 'lerm' ),
-				'clearGallery'        => __( 'Clear gallery', 'lerm' ),
-				'noMedia'             => __( 'No image selected.', 'lerm' ),
-				'noGallery'           => __( 'No gallery images selected.', 'lerm' ),
-				'searchPrompt'        => __( 'Start typing to search.', 'lerm' ),
-				'searchMinPrompt'     => __( 'Type more characters to search.', 'lerm' ),
-				'loadingResults'      => __( 'Loading results...', 'lerm' ),
-				'noResults'           => __( 'No matching results found.', 'lerm' ),
-				'loadMoreResults'     => __( 'Load more', 'lerm' ),
-				'clearSelection'      => __( 'Clear selection', 'lerm' ),
-				'removeSelection'     => __( 'Remove selection', 'lerm' ),
-				'saving'              => __( 'Saving...', 'lerm' ),
-				'saveSuccess'         => __( 'Settings saved.', 'lerm' ),
-				'saveError'           => __( 'Unable to save the settings right now.', 'lerm' ),
-				'resetting'           => __( 'Resetting...', 'lerm' ),
-				'resetSectionSuccess' => __( 'The current page has been reset to defaults.', 'lerm' ),
-				'resetAllSuccess'     => __( 'All sections have been reset to defaults.', 'lerm' ),
-				'resetError'          => __( 'Unable to reset the settings right now.', 'lerm' ),
-				'confirmResetSection' => __( 'Reset the current page back to its default values?', 'lerm' ),
-				'confirmResetAll'     => __( 'Reset every section on this page back to default values?', 'lerm' ),
-				'confirmNavigate'     => __( 'You have unsaved changes in this tab. Leave without saving?', 'lerm' ),
-				'confirmLeave'        => __( 'You have unsaved changes that have not been saved yet.', 'lerm' ),
-				'statusReady'         => __( 'Synced', 'lerm' ),
-				'statusDirty'         => __( 'Unsaved changes', 'lerm' ),
-				'statusSaving'        => __( 'Saving...', 'lerm' ),
-				'statusResetting'     => __( 'Resetting...', 'lerm' ),
-				'statusSaved'         => __( 'Saved', 'lerm' ),
-				'statusError'         => __( 'Error', 'lerm' ),
-				'groupAdd'            => __( 'Add item', 'lerm' ),
-				'groupRemove'         => __( 'Remove', 'lerm' ),
-				'groupEmpty'          => __( 'No items added yet.', 'lerm' ),
-				'confirmRemoveItem'   => __( 'Remove this item?', 'lerm' ),
-				'exportSuccess'       => __( 'Current settings snapshot generated.', 'lerm' ),
-				'importSuccess'       => __( 'Settings imported successfully.', 'lerm' ),
-				'importError'         => __( 'Unable to import the provided settings JSON.', 'lerm' ),
-				'confirmImport'       => __( 'Importing will overwrite the current saved settings. Continue?', 'lerm' ),
-				'debugCopy'           => __( 'Copy JSON', 'lerm' ),
-				'debugCopied'         => __( 'Copied', 'lerm' ),
-			)
+			I18nStrings::for_admin_page( $code_editor_settings )
 		);
 	}
 
@@ -342,8 +297,7 @@ final class OptionsPage {
 
 						<?php
 						$active_section_definition = is_array( $active_section ) ? $active_section : array();
-						$active_section_fields     = PageSchema::section_fields( $active_section_definition );
-						$active_section_groups     = $this->group_fields( $active_section_definition, $active_section_fields );
+						$active_section_groups     = PageSchema::section_groups( $active_section_definition );
 						$current_subsection        = $this->section_uses_subsections( $active_section_definition, $active_section_groups )
 							? $this->current_subsection_for_section( (string) $current_tab, $active_section_groups )
 							: '';
@@ -362,7 +316,7 @@ final class OptionsPage {
 							<?php foreach ( $sections as $section_id => $section ) : ?>
 								<?php
 								$section_fields     = PageSchema::section_fields( $section );
-								$section_groups     = $this->group_fields( $section, $section_fields );
+								$section_groups     = PageSchema::section_groups( $section );
 								$use_subsections    = $this->section_uses_subsections( $section, $section_groups );
 								$current_subsection = $use_subsections ? $this->current_subsection_for_section( (string) $section_id, $section_groups ) : '';
 								$section_errors     = $this->section_flash_errors( $flash, (string) $section_id );
@@ -601,19 +555,6 @@ final class OptionsPage {
 				$this->collect_data_sources_from_fields( $item['fields'], $sources );
 			}
 		}
-	}
-
-	/**
-	 * Group fields by their configured subsection definition.
-	 *
-	 * @param array<string, mixed>             $section Section definition.
-	 * @param array<int, array<string, mixed>> $fields  Field definitions.
-	 * @return array<int, array<string, mixed>>
-	 */
-	private function group_fields( array $section, array $fields ): array {
-		unset( $fields );
-
-		return PageSchema::section_groups( $section );
 	}
 
 	/**
@@ -1717,7 +1658,7 @@ final class OptionsPage {
 
 		foreach ( PageSchema::sections( $this->definition ) as $section_id => $section ) {
 			$section_fields  = PageSchema::section_fields( $section );
-			$section_groups  = $this->group_fields( $section, $section_fields );
+			$section_groups  = PageSchema::section_groups( $section );
 			$use_subsections = $this->section_uses_subsections( $section, $section_groups );
 
 			foreach ( $section_fields as $field ) {
@@ -2209,6 +2150,17 @@ final class OptionsPage {
 	}
 
 	/**
+	 * Asset path, delegated to resolvers that expose filesystem locations.
+	 */
+	private function asset_path( string $asset ): string {
+		if ( $this->asset_resolver instanceof AssetPathResolver ) {
+			return $this->asset_resolver->path( $asset );
+		}
+
+		return PackageAssets::path( $asset );
+	}
+
+	/**
 	 * Resolve the built JavaScript asset metadata, falling back to the packaged
 	 * browser file for source checkouts that have not run the build yet.
 	 *
@@ -2221,9 +2173,8 @@ final class OptionsPage {
 			'dependencies' => $dependencies,
 			'version'      => $this->asset_version(),
 		);
-		$asset_dir    = dirname( __DIR__, 3 ) . '/assets';
-		$script_file  = $asset_dir . '/build/admin-config.js';
-		$asset_file   = $asset_dir . '/build/admin-config.asset.php';
+		$script_file  = $this->asset_path( 'build/admin-config.js' );
+		$asset_file   = $this->asset_path( 'build/admin-config.asset.php' );
 
 		if ( ! is_readable( $script_file ) || ! is_readable( $asset_file ) ) {
 			return $fallback;
@@ -2256,8 +2207,8 @@ final class OptionsPage {
 	private function asset_version(): string {
 		$version = $this->asset_resolver->version();
 		$assets  = array(
-			dirname( __DIR__, 3 ) . '/assets/admin-config.css',
-			dirname( __DIR__, 3 ) . '/assets/admin-config.js',
+			$this->asset_path( 'admin-config.css' ),
+			$this->asset_path( 'admin-config.js' ),
 		);
 		$mtime   = 0;
 

--- a/packages/AdminConfig/src/Framework/Contracts/AssetPathResolver.php
+++ b/packages/AdminConfig/src/Framework/Contracts/AssetPathResolver.php
@@ -1,0 +1,24 @@
+<?php // phpcs:disable WordPress.Files.FileName
+/**
+ * Optional contract for resolving framework asset file paths.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\Framework\Contracts;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+interface AssetPathResolver extends AssetResolver {
+
+	/**
+	 * Return the full filesystem path for a framework asset file.
+	 *
+	 * @param string $filename Asset filename relative to the framework assets directory.
+	 */
+	public function path( string $filename ): string;
+}

--- a/packages/AdminConfig/src/Framework/Resolvers/DefaultAssetResolver.php
+++ b/packages/AdminConfig/src/Framework/Resolvers/DefaultAssetResolver.php
@@ -16,24 +16,28 @@ declare( strict_types=1 );
 namespace Lerm\AdminConfig\Framework\Resolvers;
 
 use Lerm\AdminConfig\Version;
-use Lerm\AdminConfig\Framework\Contracts\AssetResolver;
+use Lerm\AdminConfig\Framework\Contracts\AssetPathResolver;
+use Lerm\AdminConfig\Framework\Support\PackageAssets;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-final class DefaultAssetResolver implements AssetResolver {
+final class DefaultAssetResolver implements AssetPathResolver {
 
 	private string $assets_url;
+	private string $assets_path;
 	private string $version_constant;
 
 	/**
 	 * @param string $assets_url       Public URL of the framework assets directory (trailing slash optional).
 	 * @param string $version_constant Name of the PHP constant holding the version string.
 	 *                                 Falls back to the package version when not defined.
+	 * @param string $assets_path      Filesystem path of the framework assets directory.
 	 */
-	public function __construct( string $assets_url, string $version_constant = 'LERM_VERSION' ) {
+	public function __construct( string $assets_url, string $version_constant = 'LERM_VERSION', string $assets_path = '' ) {
 		$this->assets_url       = trailingslashit( $assets_url );
+		$this->assets_path      = '' !== $assets_path ? rtrim( $assets_path, '/\\' ) : PackageAssets::directory();
 		$this->version_constant = $version_constant;
 	}
 
@@ -43,5 +47,9 @@ final class DefaultAssetResolver implements AssetResolver {
 
 	public function version(): string {
 		return Version::from_constant( $this->version_constant );
+	}
+
+	public function path( string $filename ): string {
+		return $this->assets_path . '/' . ltrim( $filename, '/\\' );
 	}
 }

--- a/packages/AdminConfig/src/Framework/Support/I18nStrings.php
+++ b/packages/AdminConfig/src/Framework/Support/I18nStrings.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Localized strings used by AdminConfig JavaScript runtimes.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\Framework\Support;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class I18nStrings {
+
+	/**
+	 * @param mixed $code_editor_settings Code editor settings returned by wp_enqueue_code_editor().
+	 * @return array<string, mixed>
+	 */
+	public static function for_admin_page( $code_editor_settings ): array {
+		return array(
+			'restUrl'             => rest_url( 'lerm-admin-config/v1/' ),
+			'restNonce'           => wp_create_nonce( 'wp_rest' ),
+			'codeEditor'          => $code_editor_settings,
+			'selectMedia'         => __( 'Choose image', 'lerm' ),
+			'useMedia'            => __( 'Use this image', 'lerm' ),
+			'selectFile'          => __( 'Choose file', 'lerm' ),
+			'useFile'             => __( 'Use this file', 'lerm' ),
+			'selectImages'        => __( 'Choose images', 'lerm' ),
+			'useImages'           => __( 'Use these images', 'lerm' ),
+			'removeMedia'         => __( 'Remove image', 'lerm' ),
+			'clearGallery'        => __( 'Clear gallery', 'lerm' ),
+			'noMedia'             => __( 'No image selected.', 'lerm' ),
+			'noGallery'           => __( 'No gallery images selected.', 'lerm' ),
+			'searchPrompt'        => __( 'Start typing to search.', 'lerm' ),
+			'searchMinPrompt'     => __( 'Type more characters to search.', 'lerm' ),
+			'loadingResults'      => __( 'Loading results...', 'lerm' ),
+			'noResults'           => __( 'No matching results found.', 'lerm' ),
+			'loadMoreResults'     => __( 'Load more', 'lerm' ),
+			'clearSelection'      => __( 'Clear selection', 'lerm' ),
+			'removeSelection'     => __( 'Remove selection', 'lerm' ),
+			'saving'              => __( 'Saving...', 'lerm' ),
+			'saveSuccess'         => __( 'Settings saved.', 'lerm' ),
+			'saveError'           => __( 'Unable to save the settings right now.', 'lerm' ),
+			'resetting'           => __( 'Resetting...', 'lerm' ),
+			'resetSectionSuccess' => __( 'The current page has been reset to defaults.', 'lerm' ),
+			'resetAllSuccess'     => __( 'All sections have been reset to defaults.', 'lerm' ),
+			'resetError'          => __( 'Unable to reset the settings right now.', 'lerm' ),
+			'confirmResetSection' => __( 'Reset the current page back to its default values?', 'lerm' ),
+			'confirmResetAll'     => __( 'Reset every section on this page back to default values?', 'lerm' ),
+			'confirmNavigate'     => __( 'You have unsaved changes in this tab. Leave without saving?', 'lerm' ),
+			'confirmLeave'        => __( 'You have unsaved changes that have not been saved yet.', 'lerm' ),
+			'statusReady'         => __( 'Synced', 'lerm' ),
+			'statusDirty'         => __( 'Unsaved changes', 'lerm' ),
+			'statusSaving'        => __( 'Saving...', 'lerm' ),
+			'statusResetting'     => __( 'Resetting...', 'lerm' ),
+			'statusSaved'         => __( 'Saved', 'lerm' ),
+			'statusError'         => __( 'Error', 'lerm' ),
+			'groupAdd'            => __( 'Add item', 'lerm' ),
+			'groupRemove'         => __( 'Remove', 'lerm' ),
+			'groupEmpty'          => __( 'No items added yet.', 'lerm' ),
+			'confirmRemoveItem'   => __( 'Remove this item?', 'lerm' ),
+			'exportSuccess'       => __( 'Current settings snapshot generated.', 'lerm' ),
+			'importSuccess'       => __( 'Settings imported successfully.', 'lerm' ),
+			'importError'         => __( 'Unable to import the provided settings JSON.', 'lerm' ),
+			'confirmImport'       => __( 'Importing will overwrite the current saved settings. Continue?', 'lerm' ),
+			'debugCopy'           => __( 'Copy JSON', 'lerm' ),
+			'debugCopied'         => __( 'Copied', 'lerm' ),
+		);
+	}
+}

--- a/packages/AdminConfig/src/Framework/Support/PackageAssets.php
+++ b/packages/AdminConfig/src/Framework/Support/PackageAssets.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Package-local asset path helpers.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\Framework\Support;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class PackageAssets {
+
+	public static function directory(): string {
+		return dirname( __DIR__, 3 ) . '/assets';
+	}
+
+	public static function path( string $filename ): string {
+		return self::directory() . '/' . ltrim( $filename, '/\\' );
+	}
+}

--- a/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
@@ -12,8 +12,10 @@ namespace Lerm\AdminConfig\WordPress\Containers;
 use Lerm\AdminConfig\Compiler\CompiledSchema;
 use Lerm\AdminConfig\Contracts\Container;
 use Lerm\AdminConfig\Stores\StoreResolver;
+use Lerm\AdminConfig\Framework\Contracts\AssetPathResolver;
 use Lerm\AdminConfig\Framework\Admin\OptionsPage;
 use Lerm\AdminConfig\Framework\Framework;
+use Lerm\AdminConfig\Framework\Support\PackageAssets;
 use Lerm\AdminConfig\Framework\Support\PageSchema;
 use Lerm\AdminConfig\WordPress\Support\ValidationFlash;
 
@@ -361,9 +363,8 @@ final class MetaboxContainer implements Container {
 			'dependencies' => $dependencies,
 			'version'      => $this->asset_version(),
 		);
-		$asset_dir    = dirname( __DIR__, 3 ) . '/assets';
-		$script_file  = $asset_dir . '/build/block-panel.js';
-		$asset_file   = $asset_dir . '/build/block-panel.asset.php';
+		$script_file  = $this->asset_path( 'build/block-panel.js' );
+		$asset_file   = $this->asset_path( 'build/block-panel.asset.php' );
 
 		if ( ! is_readable( $script_file ) || ! is_readable( $asset_file ) ) {
 			return $fallback;
@@ -392,6 +393,16 @@ final class MetaboxContainer implements Container {
 
 	private function asset_url( string $asset ): string {
 		return $this->framework->asset_resolver()->url( $asset );
+	}
+
+	private function asset_path( string $asset ): string {
+		$resolver = $this->framework->asset_resolver();
+
+		if ( $resolver instanceof AssetPathResolver ) {
+			return $resolver->path( $asset );
+		}
+
+		return PackageAssets::path( $asset );
 	}
 
 	private function asset_version(): string {

--- a/packages/AdminConfig/src/WordPress/PluginAssetResolver.php
+++ b/packages/AdminConfig/src/WordPress/PluginAssetResolver.php
@@ -10,13 +10,13 @@ declare( strict_types=1 );
 namespace Lerm\AdminConfig\WordPress;
 
 use Lerm\AdminConfig\Version;
-use Lerm\AdminConfig\Framework\Contracts\AssetResolver;
+use Lerm\AdminConfig\Framework\Contracts\AssetPathResolver;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-final class PluginAssetResolver implements AssetResolver {
+final class PluginAssetResolver implements AssetPathResolver {
 
 	private string $asset_plugin_file;
 	private string $version_constant;
@@ -32,6 +32,10 @@ final class PluginAssetResolver implements AssetResolver {
 
 	public function version(): string {
 		return Version::from_constant( $this->version_constant );
+	}
+
+	public function path( string $filename ): string {
+		return dirname( $this->asset_plugin_file ) . '/assets/' . ltrim( $filename, '/\\' );
 	}
 
 	private function resolve_asset_plugin_file( string $plugin_file ): string {


### PR DESCRIPTION
## Summary
- remove the empty OptionsPage group_fields wrapper and call PageSchema directly
- extract classic admin JS localization strings into I18nStrings
- centralize AdminConfig asset filesystem paths behind AssetPathResolver and PackageAssets
- consolidate SchemaCompiler field metadata copying into one helper

## Validation
- composer ci
- npm run check:phase2

## Notes
- Existing theme-side unstaged changes were left untouched: app/Theme/AdminConfig/CategoryTaxonomySchema.php and app/Theme/AdminConfig/LayoutMetaboxSchema.php.