### PR TITLE
[codex] Move simple AdminConfig field renderers into definitions

### DIFF
--- a/packages/AdminConfig/CHANGELOG.md
+++ b/packages/AdminConfig/CHANGELOG.md
@@ -83,6 +83,8 @@ The format follows Keep a Changelog and the package uses Semantic Versioning onc
   duplicate logic.
 - Classic admin field rows and build asset metadata resolution now use shared
   helpers to reduce branching and duplicated enqueue plumbing.
+- Low-coupling classic admin field renderers for notices, backup tools, and
+  sorters now live in field type definitions instead of `OptionsPage`.
 - The block editor field matrix now separates Phase 4 collection fields from
   read-only fields and is checked against JS/PHP field contracts.
 - Admin pages now prefer the built `assets/build/admin-config.js` bundle while retaining a packaged browser-file fallback for source checkouts.

--- a/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
+++ b/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
@@ -840,71 +840,6 @@ final class OptionsPage {
 	}
 
 	/**
-	 * Render read-only notice / helper HTML.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 */
-	public function render_notice_field( array $field ): void {
-		$html = isset( $field['html'] ) && is_scalar( $field['html'] ) ? (string) $field['html'] : '';
-
-		if ( '' === trim( $html ) ) {
-			return;
-		}
-
-		echo '<div class="lerm-settings-notice">';
-		echo wp_kses(
-			$html,
-			array(
-				'a'      => array(
-					'href'   => true,
-					'target' => true,
-					'rel'    => true,
-					'class'  => true,
-				),
-				'br'     => array(),
-				'code'   => array(),
-				'em'     => array(),
-				'p'      => array(
-					'class' => true,
-				),
-				'span'   => array(
-					'class' => true,
-				),
-				'strong' => array(),
-			)
-		);
-		echo '</div>';
-	}
-
-	/**
-	 * Render backup export/import controls.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 */
-	public function render_backup_tools_field( array $field ): void {
-		$export_label = (string) ( $field['export_label'] ?? __( 'Export current settings', 'lerm' ) );
-		$import_label = (string) ( $field['import_label'] ?? __( 'Import settings JSON', 'lerm' ) );
-		$placeholder  = (string) ( $field['placeholder'] ?? __( '{ "example": "Paste a backup snapshot here" }', 'lerm' ) );
-
-		echo '<div class="lerm-backup-tools">';
-		echo '<div class="lerm-backup-tools__block">';
-		echo '<div class="lerm-backup-tools__header">';
-		echo '<strong>' . esc_html( $export_label ) . '</strong>';
-		echo '<button type="button" class="button button-secondary" data-lerm-backup-export>' . esc_html__( 'Generate snapshot', 'lerm' ) . '</button>';
-		echo '</div>';
-		echo '<textarea class="large-text code lerm-backup-tools__export" rows="10" readonly data-lerm-backup-export-output></textarea>';
-		echo '</div>';
-		echo '<div class="lerm-backup-tools__block">';
-		echo '<div class="lerm-backup-tools__header">';
-		echo '<strong>' . esc_html( $import_label ) . '</strong>';
-		echo '<button type="button" class="button button-primary" data-lerm-backup-import>' . esc_html__( 'Import snapshot', 'lerm' ) . '</button>';
-		echo '</div>';
-		echo '<textarea class="large-text code lerm-backup-tools__import" rows="10" data-lerm-backup-import-input placeholder="' . esc_attr( $placeholder ) . '"></textarea>';
-		echo '</div>';
-		echo '</div>';
-	}
-
-	/**
 	 * Render fieldsets as a compact grid of nested controls.
 	 *
 	 * @param array<string, mixed> $field      Field definition.
@@ -1299,32 +1234,6 @@ final class OptionsPage {
 	}
 
 	/**
-	 * Render a radio or button-set field.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Field value.
-	 */
-	public function render_choice_field( array $field, $value, string $field_name ): void {
-		$choices = PageSchema::choices( $field );
-		$current = is_scalar( $value ) ? (string) $value : '';
-		$class   = ( ( $field['type'] ?? 'radio' ) === 'button_set' ) ? 'lerm-button-set' : 'lerm-radio-list';
-
-		echo '<fieldset class="' . esc_attr( $class ) . '"><legend class="screen-reader-text">' . esc_html( (string) $field['label'] ) . '</legend>';
-
-		foreach ( $choices as $choice_value => $choice_label ) {
-			printf(
-				'<label><input type="radio" name="%1$s" value="%2$s" %3$s data-lerm-controller="1"> <span>%4$s</span></label>',
-				esc_attr( $field_name ),
-				esc_attr( $choice_value ),
-				checked( $current, (string) $choice_value, false ),
-				esc_html( $choice_label )
-			);
-		}
-
-		echo '</fieldset>';
-	}
-
-	/**
 	 * Render a gallery field.
 	 *
 	 * @param array<string, mixed> $field Field definition.
@@ -1358,96 +1267,6 @@ final class OptionsPage {
 		echo '<button type="button" class="button button-secondary button-link-delete lerm-gallery-remove" ' . ( empty( $ids ) ? 'hidden' : '' ) . '>' . esc_html__( 'Clear gallery', 'lerm' ) . '</button>';
 		echo '</div>';
 		echo '</div>';
-	}
-
-	/**
-	 * Render a sorter field.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Field value.
-	 */
-	public function render_sorter_field( array $field, $value ): void {
-		$state      = $this->sorter_state( $field, $value );
-		$field_id   = (string) $field['id'];
-		$name_base  = $this->option_name() . '[' . $field_id . ']';
-		$order      = $state['order'];
-		$enabled    = $state['enabled'];
-		$label_text = (string) $field['label'];
-
-		echo '<div class="lerm-sorter" data-target="' . esc_attr( $field_id ) . '">';
-		echo '<p class="description">' . esc_html__( 'Drag to reorder. Checked items stay enabled; unchecked items are hidden.', 'lerm' ) . '</p>';
-		echo '<ul class="lerm-sorter-list">';
-
-		foreach ( $order as $key => $label ) {
-			$is_enabled = in_array( $key, $enabled, true );
-			echo '<li class="lerm-sorter-item">';
-			echo '<span class="lerm-sorter-handle" aria-hidden="true">&#8645;</span>';
-			echo '<input type="hidden" name="' . esc_attr( $name_base . '[order][]' ) . '" value="' . esc_attr( $key ) . '">';
-			echo '<label>';
-			echo '<input type="checkbox" name="' . esc_attr( $name_base . '[enabled][]' ) . '" value="' . esc_attr( $key ) . '" ' . checked( $is_enabled, true, false ) . '>';
-			echo '<span>' . esc_html( $label ) . '</span>';
-			echo '</label>';
-			echo '</li>';
-		}
-
-		echo '</ul>';
-		echo '<span class="screen-reader-text">' . esc_html( $label_text ) . '</span>';
-		echo '</div>';
-	}
-
-	/**
-	 * Normalize sorter values into ordered labels and enabled keys.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Field value.
-	 * @return array{order: array<string, string>, enabled: array<int, string>}
-	 */
-	public function sorter_state( array $field, $value ): array {
-		$choices = PageSchema::choices( $field );
-		$order   = array();
-		$enabled = array();
-
-		if ( is_array( $value ) ) {
-			if ( isset( $value['order'] ) && is_array( $value['order'] ) ) {
-				$order_keys = array_map( 'strval', $value['order'] );
-				$enabled    = isset( $value['enabled'] ) && is_array( $value['enabled'] )
-					? array_map( 'strval', $value['enabled'] )
-					: array();
-
-				foreach ( $order_keys as $key ) {
-					if ( isset( $choices[ $key ] ) ) {
-						$order[ $key ] = $choices[ $key ];
-					}
-				}
-			} else {
-				$enabled_values  = is_array( $value['enabled'] ?? null ) ? $value['enabled'] : array();
-				$disabled_values = is_array( $value['disabled'] ?? null ) ? $value['disabled'] : array();
-
-				foreach ( array_keys( $enabled_values ) as $key ) {
-					if ( isset( $choices[ $key ] ) ) {
-						$order[ $key ] = $choices[ $key ];
-						$enabled[]     = $key;
-					}
-				}
-
-				foreach ( array_keys( $disabled_values ) as $key ) {
-					if ( isset( $choices[ $key ] ) && ! isset( $order[ $key ] ) ) {
-						$order[ $key ] = $choices[ $key ];
-					}
-				}
-			}
-		}
-
-		foreach ( $choices as $key => $label ) {
-			if ( ! isset( $order[ $key ] ) ) {
-				$order[ $key ] = $label;
-			}
-		}
-
-		return array(
-			'order'   => $order,
-			'enabled' => $enabled,
-		);
 	}
 
 	/**

--- a/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
@@ -41,7 +41,9 @@ final class StructuredFieldTypes {
 	private static function notice_definition(): array {
 		return array(
 			'render'   => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
-				$page->render_notice_field( $field );
+				unset( $value, $field_name, $page );
+
+				self::render_notice_field( $field );
 			},
 			'sanitize' => static function () {
 				return '';
@@ -137,7 +139,9 @@ final class StructuredFieldTypes {
 	private static function sorter_definition(): array {
 		return array(
 			'render'        => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
-				$page->render_sorter_field( $field, $value );
+				unset( $page );
+
+				self::render_sorter_field( $field, $value, $field_name );
 			},
 			'render_nested' => static function (): void {
 				self::render_nested_warning( __( 'Sorter fields cannot be nested inside a fieldset or group.', 'lerm' ) );
@@ -191,6 +195,126 @@ final class StructuredFieldTypes {
 				'control' => 'wp_editor',
 				'nested'  => true,
 			),
+		);
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 */
+	private static function render_notice_field( array $field ): void {
+		$html = isset( $field['html'] ) && is_scalar( $field['html'] ) ? (string) $field['html'] : '';
+
+		if ( '' === trim( $html ) ) {
+			return;
+		}
+
+		echo '<div class="lerm-settings-notice">';
+		echo wp_kses(
+			$html,
+			array(
+				'a'      => array(
+					'href'   => true,
+					'target' => true,
+					'rel'    => true,
+					'class'  => true,
+				),
+				'br'     => array(),
+				'code'   => array(),
+				'em'     => array(),
+				'p'      => array(
+					'class' => true,
+				),
+				'span'   => array(
+					'class' => true,
+				),
+				'strong' => array(),
+			)
+		);
+		echo '</div>';
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 * @param mixed                $value
+	 */
+	private static function render_sorter_field( array $field, $value, string $field_name ): void {
+		$state      = self::sorter_state( $field, $value );
+		$field_id   = (string) $field['id'];
+		$order      = $state['order'];
+		$enabled    = $state['enabled'];
+		$label_text = (string) ( $field['label'] ?? '' );
+
+		echo '<div class="lerm-sorter" data-target="' . esc_attr( $field_id ) . '">';
+		echo '<p class="description">' . esc_html__( 'Drag to reorder. Checked items stay enabled; unchecked items are hidden.', 'lerm' ) . '</p>';
+		echo '<ul class="lerm-sorter-list">';
+
+		foreach ( $order as $key => $label ) {
+			$is_enabled = in_array( $key, $enabled, true );
+			echo '<li class="lerm-sorter-item">';
+			echo '<span class="lerm-sorter-handle" aria-hidden="true">&#8645;</span>';
+			echo '<input type="hidden" name="' . esc_attr( $field_name . '[order][]' ) . '" value="' . esc_attr( $key ) . '">';
+			echo '<label>';
+			echo '<input type="checkbox" name="' . esc_attr( $field_name . '[enabled][]' ) . '" value="' . esc_attr( $key ) . '" ' . checked( $is_enabled, true, false ) . '>';
+			echo '<span>' . esc_html( $label ) . '</span>';
+			echo '</label>';
+			echo '</li>';
+		}
+
+		echo '</ul>';
+		echo '<span class="screen-reader-text">' . esc_html( $label_text ) . '</span>';
+		echo '</div>';
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 * @param mixed                $value
+	 * @return array{order: array<string, string>, enabled: array<int, string>}
+	 */
+	private static function sorter_state( array $field, $value ): array {
+		$choices = PageSchema::choices( $field );
+		$order   = array();
+		$enabled = array();
+
+		if ( is_array( $value ) ) {
+			if ( isset( $value['order'] ) && is_array( $value['order'] ) ) {
+				$order_keys = array_map( 'strval', $value['order'] );
+				$enabled    = isset( $value['enabled'] ) && is_array( $value['enabled'] )
+					? array_map( 'strval', $value['enabled'] )
+					: array();
+
+				foreach ( $order_keys as $key ) {
+					if ( isset( $choices[ $key ] ) ) {
+						$order[ $key ] = $choices[ $key ];
+					}
+				}
+			} else {
+				$enabled_values  = is_array( $value['enabled'] ?? null ) ? $value['enabled'] : array();
+				$disabled_values = is_array( $value['disabled'] ?? null ) ? $value['disabled'] : array();
+
+				foreach ( array_keys( $enabled_values ) as $key ) {
+					if ( isset( $choices[ $key ] ) ) {
+						$order[ $key ] = $choices[ $key ];
+						$enabled[]     = $key;
+					}
+				}
+
+				foreach ( array_keys( $disabled_values ) as $key ) {
+					if ( isset( $choices[ $key ] ) && ! isset( $order[ $key ] ) ) {
+						$order[ $key ] = $choices[ $key ];
+					}
+				}
+			}
+		}
+
+		foreach ( $choices as $key => $label ) {
+			if ( ! isset( $order[ $key ] ) ) {
+				$order[ $key ] = $label;
+			}
+		}
+
+		return array(
+			'order'   => $order,
+			'enabled' => $enabled,
 		);
 	}
 

--- a/packages/AdminConfig/src/Framework/FieldTypes/ToolFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/ToolFieldTypes.php
@@ -24,7 +24,9 @@ final class ToolFieldTypes {
 		return array(
 			'backup_tools' => array(
 				'render'   => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
-					$page->render_backup_tools_field( $field );
+					unset( $value, $field_name, $page );
+
+					self::render_backup_tools_field( $field );
 				},
 				'sanitize' => static function () {
 					return '';
@@ -35,5 +37,31 @@ final class ToolFieldTypes {
 				),
 			),
 		);
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 */
+	private static function render_backup_tools_field( array $field ): void {
+		$export_label = (string) ( $field['export_label'] ?? __( 'Export current settings', 'lerm' ) );
+		$import_label = (string) ( $field['import_label'] ?? __( 'Import settings JSON', 'lerm' ) );
+		$placeholder  = (string) ( $field['placeholder'] ?? __( '{ "example": "Paste a backup snapshot here" }', 'lerm' ) );
+
+		echo '<div class="lerm-backup-tools">';
+		echo '<div class="lerm-backup-tools__block">';
+		echo '<div class="lerm-backup-tools__header">';
+		echo '<strong>' . esc_html( $export_label ) . '</strong>';
+		echo '<button type="button" class="button button-secondary" data-lerm-backup-export>' . esc_html__( 'Generate snapshot', 'lerm' ) . '</button>';
+		echo '</div>';
+		echo '<textarea class="large-text code lerm-backup-tools__export" rows="10" readonly data-lerm-backup-export-output></textarea>';
+		echo '</div>';
+		echo '<div class="lerm-backup-tools__block">';
+		echo '<div class="lerm-backup-tools__header">';
+		echo '<strong>' . esc_html( $import_label ) . '</strong>';
+		echo '<button type="button" class="button button-primary" data-lerm-backup-import>' . esc_html__( 'Import snapshot', 'lerm' ) . '</button>';
+		echo '</div>';
+		echo '<textarea class="large-text code lerm-backup-tools__import" rows="10" data-lerm-backup-import-input placeholder="' . esc_attr( $placeholder ) . '"></textarea>';
+		echo '</div>';
+		echo '</div>';
 	}
 }

--- a/packages/AdminConfig/tests/Unit/FieldRendererCallbacksTest.php
+++ b/packages/AdminConfig/tests/Unit/FieldRendererCallbacksTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Field renderer callback tests.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\Tests\Unit;
+
+use Lerm\AdminConfig\Framework\Admin\OptionsPage;
+use Lerm\AdminConfig\Framework\Contracts\AssetResolver;
+use Lerm\AdminConfig\Framework\FieldTypes\FieldTypeRegistry;
+use Lerm\AdminConfig\Framework\FieldTypes\StructuredFieldTypes;
+use Lerm\AdminConfig\Framework\FieldTypes\ToolFieldTypes;
+use Lerm\AdminConfig\Framework\Storage\OptionStore;
+use Lerm\AdminConfig\Tests\Support\TestCase;
+
+final class FieldRendererCallbacksTest extends TestCase {
+
+	public function testStructuredNoticeRendersFromFieldTypeCallback(): void {
+		$page  = $this->options_page();
+		$field = array(
+			'id'    => 'intro_notice',
+			'type'  => 'notice',
+			'label' => '',
+			'html'  => '<p class="notice-copy"><strong>Heads up</strong></p>',
+		);
+
+		$output = $this->render_field( $page, $field, array() );
+
+		$this->assertStringContainsString( 'lerm-settings-notice', $output );
+		$this->assertStringContainsString( '<strong>Heads up</strong>', $output );
+	}
+
+	public function testToolBackupRendererRendersFromFieldTypeCallback(): void {
+		$page  = $this->options_page();
+		$field = array(
+			'id'           => 'backup',
+			'type'         => 'backup_tools',
+			'label'        => 'Backup',
+			'export_label' => 'Export config',
+			'import_label' => 'Import config',
+		);
+
+		$output = $this->render_field( $page, $field, array() );
+
+		$this->assertStringContainsString( 'Export config', $output );
+		$this->assertStringContainsString( 'data-lerm-backup-export', $output );
+		$this->assertStringContainsString( 'data-lerm-backup-import', $output );
+	}
+
+	public function testStructuredSorterRendersFromFieldTypeCallback(): void {
+		$page  = $this->options_page();
+		$field = array(
+			'id'      => 'layout_sort',
+			'type'    => 'sorter',
+			'label'   => 'Layout sort',
+			'choices' => array(
+				'header'  => 'Header',
+				'sidebar' => 'Sidebar',
+				'footer'  => 'Footer',
+			),
+		);
+
+		$output = $this->render_field(
+			$page,
+			$field,
+			array(
+				'layout_sort' => array(
+					'order'   => array( 'sidebar', 'header' ),
+					'enabled' => array( 'header' ),
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'name="options_framework[layout_sort][order][]" value="sidebar"', $output );
+		$this->assertStringContainsString( 'name="options_framework[layout_sort][enabled][]" value="header"  checked="checked"', $output );
+		$this->assertStringContainsString( '<span>Footer</span>', $output );
+	}
+
+	private function options_page(): OptionsPage {
+		$field_types = new FieldTypeRegistry();
+
+		foreach ( array_merge( StructuredFieldTypes::definitions(), ToolFieldTypes::definitions() ) as $type => $field_type_definition ) {
+			$field_types->register( (string) $type, $field_type_definition );
+		}
+
+		$definition = array(
+			'id'    => 'unit_field_renderer_callbacks',
+			'store' => array(
+				'type' => 'option',
+				'key'  => 'unit_field_renderer_callbacks',
+			),
+		);
+		$store      = new OptionStore( $definition, $field_types );
+		$resolver   = new class() implements AssetResolver {
+			public function url( string $filename ): string {
+				return 'https://example.test/assets/' . ltrim( $filename, '/' );
+			}
+
+			public function version(): string {
+				return 'unit-version';
+			}
+		};
+
+		return new OptionsPage( $definition, $store, $field_types, $resolver, false );
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 * @param array<string, mixed> $values
+	 */
+	private function render_field( OptionsPage $page, array $field, array $values ): string {
+		ob_start();
+
+		try {
+			$page->render_field( $field, $values, 'general' );
+
+			return (string) ob_get_clean();
+		} catch ( \Throwable $throwable ) {
+			ob_end_clean();
+			throw $throwable;
+		}
+	}
+}

--- a/packages/AdminConfig/tests/bootstrap.php
+++ b/packages/AdminConfig/tests/bootstrap.php
@@ -241,6 +241,14 @@ if ( ! function_exists( 'esc_html__' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_kses' ) ) {
+	function wp_kses( string $content, array $allowed_html ): string {
+		unset( $allowed_html );
+
+		return $content;
+	}
+}
+
 if ( ! function_exists( 'checked' ) ) {
 	function checked( $checked, $current = true, bool $display = true ): string {
 		$result = (string) $checked === (string) $current ? ' checked="checked"' : '';


### PR DESCRIPTION
## Summary
- move classic notice rendering into StructuredFieldTypes
- move backup tools rendering into ToolFieldTypes
- move sorter rendering/state normalization into StructuredFieldTypes
- remove the now-unused OptionsPage render_notice_field, render_backup_tools_field, render_choice_field, render_sorter_field, and sorter_state methods
- add unit coverage for field-type callback rendering paths

## Validation
- composer ci
- npm run check:phase2

## Notes
- Existing theme-side unstaged changes were left untouched: app/Theme/AdminConfig/CategoryTaxonomySchema.php and app/Theme/AdminConfig/LayoutMetaboxSchema.php.