### PR TITLE
[codex] Remove OptionsPage container delegates

### DIFF
--- a/packages/AdminConfig/CHANGELOG.md
+++ b/packages/AdminConfig/CHANGELOG.md
@@ -90,6 +90,9 @@ The format follows Keep a Changelog and the package uses Semantic Versioning onc
 - Classic admin structured container rendering now uses a dedicated
   `ContainerFieldRenderer`, reducing `OptionsPage` to compatibility delegates
   for fieldset, group, accordion, and tabbed fields.
+- Structured and advanced field definitions now call
+  `OptionsPage::container_field_renderer()` directly, and the temporary
+  `OptionsPage` container delegate methods have been removed.
 - PHPStan now runs with a 2G default memory limit, overridable through
   `LERM_ADMIN_CONFIG_PHPSTAN_MEMORY_LIMIT`, to keep local and CI analysis
   stable as package coverage grows.

--- a/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
+++ b/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
@@ -839,56 +839,13 @@ final class OptionsPage {
 		}
 	}
 
-	private function container_renderer(): ContainerFieldRenderer {
+	public function container_field_renderer(): ContainerFieldRenderer {
 		return new ContainerFieldRenderer(
 			$this->field_types,
 			$this,
 			$this->render_field_errors,
 			$this->current_render_path()
 		);
-	}
-
-	/**
-	 * Render fieldsets as a compact grid of nested controls.
-	 *
-	 * @param array<string, mixed> $field      Field definition.
-	 * @param mixed                $value      Field value.
-	 * @param string               $section_id Current section ID.
-	 */
-	public function render_fieldset_field( array $field, $value, string $field_name, string $section_id = '' ): void {
-		unset( $section_id );
-
-		$this->container_renderer()->render_fieldset( $field, $value, $field_name );
-	}
-
-	/**
-	 * Render accordion field panels.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Field value.
-	 */
-	public function render_accordion_field( array $field, $value, string $field_name ): void {
-		$this->container_renderer()->render_accordion( $field, $value, $field_name );
-	}
-
-	/**
-	 * Render tabbed field panels.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Field value.
-	 */
-	public function render_tabbed_field( array $field, $value, string $field_name ): void {
-		$this->container_renderer()->render_tabbed( $field, $value, $field_name );
-	}
-
-	/**
-	 * Render repeatable groups.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Field value.
-	 */
-	public function render_group_field( array $field, $value, string $field_name ): void {
-		$this->container_renderer()->render_group( $field, $value, $field_name );
 	}
 
 	/**

--- a/packages/AdminConfig/src/Framework/FieldTypes/AdvancedFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/AdvancedFieldTypes.php
@@ -37,7 +37,7 @@ final class AdvancedFieldTypes {
 	private static function typography_definition(): array {
 		return array(
 			'render'   => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
-				$page->render_fieldset_field( self::typography_field( $field ), $value, $field_name );
+				$page->container_field_renderer()->render_fieldset( self::typography_field( $field ), $value, $field_name );
 			},
 			'sanitize' => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
 				return $store->sanitize_fieldset_field( self::typography_field( $field ), $value, $strict );
@@ -89,7 +89,7 @@ final class AdvancedFieldTypes {
 	private static function accordion_definition(): array {
 		return array(
 			'render'        => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
-				$page->render_accordion_field( $field, $value, $field_name );
+				$page->container_field_renderer()->render_accordion( $field, $value, $field_name );
 			},
 			'render_nested' => static function (): void {
 				self::render_nested_warning( __( 'Accordion fields cannot be nested inside a fieldset or group.', 'lerm' ) );
@@ -109,7 +109,7 @@ final class AdvancedFieldTypes {
 	private static function tabbed_definition(): array {
 		return array(
 			'render'        => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
-				$page->render_tabbed_field( $field, $value, $field_name );
+				$page->container_field_renderer()->render_tabbed( $field, $value, $field_name );
 			},
 			'render_nested' => static function (): void {
 				self::render_nested_warning( __( 'Tabbed fields cannot be nested inside a fieldset or group.', 'lerm' ) );

--- a/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
@@ -61,7 +61,7 @@ final class StructuredFieldTypes {
 	private static function fieldset_definition(): array {
 		return array(
 			'render'   => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
-				$page->render_fieldset_field( $field, $value, $field_name );
+				$page->container_field_renderer()->render_fieldset( $field, $value, $field_name );
 			},
 			'sanitize' => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
 				return $store->sanitize_fieldset_field( $field, $value, $strict );
@@ -78,7 +78,7 @@ final class StructuredFieldTypes {
 	private static function group_definition(): array {
 		return array(
 			'render'   => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
-				$page->render_group_field( $field, $value, $field_name );
+				$page->container_field_renderer()->render_group( $field, $value, $field_name );
 			},
 			'sanitize' => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
 				return $store->sanitize_group_field( $field, $value, $strict );


### PR DESCRIPTION
## Summary
- Update structured and advanced field definitions to call `OptionsPage::container_field_renderer()` directly.
- Remove the temporary `OptionsPage` delegate methods for fieldset, group, accordion, and tabbed rendering.
- Keep the container rendering path explicit without changing output contracts.

## Validation
- `composer ci`
- `npm run check:phase2`
- `git diff --check -- packages/AdminConfig`

## Notes
- Existing local theme changes under `app/Theme/AdminConfig/` were left unstaged and are not part of this PR.