### PR TITLE
Move low-risk field sanitizers into definitions

### DIFF
--- a/packages/AdminConfig/CHANGELOG.md
+++ b/packages/AdminConfig/CHANGELOG.md
@@ -93,6 +93,9 @@ The format follows Keep a Changelog and the package uses Semantic Versioning onc
 - Structured and advanced field definitions now call
   `OptionsPage::container_field_renderer()` directly, and the temporary
   `OptionsPage` container delegate methods have been removed.
+- Low-risk structured field sanitizers for media, gallery, sorter, code
+  editor, and WordPress editor fields now live in structured field type
+  definitions instead of `OptionStore`.
 - PHPStan now runs with a 2G default memory limit, overridable through
   `LERM_ADMIN_CONFIG_PHPSTAN_MEMORY_LIMIT`, to keep local and CI analysis
   stable as package coverage grows.

--- a/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
@@ -112,7 +112,9 @@ final class StructuredFieldTypes {
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
-				return $store->sanitize_media_field( $value );
+				unset( $field, $strict, $store );
+
+				return self::sanitize_media_value( $value );
 			},
 			'client'        => array(
 				'control' => 'media',
@@ -144,7 +146,9 @@ final class StructuredFieldTypes {
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
-				return $store->sanitize_gallery_field( $value );
+				unset( $field, $strict, $store );
+
+				return self::sanitize_gallery_value( $value );
 			},
 			'client'        => array(
 				'control' => 'gallery',
@@ -167,7 +171,9 @@ final class StructuredFieldTypes {
 				self::render_nested_warning( __( 'Sorter fields cannot be nested inside a fieldset or group.', 'lerm' ) );
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
-				return $store->sanitize_sorter_field( $field, $value, $strict );
+				unset( $store );
+
+				return self::sanitize_sorter_value( $field, $value, $strict );
 			},
 			'client'        => array(
 				'control' => 'sorter',
@@ -192,7 +198,9 @@ final class StructuredFieldTypes {
 				self::render_code_editor_field( $field, $value, $field_name, $input_id, $name_template, $id_template );
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ): string {
-				return $store->sanitize_code_editor_field( $value );
+				unset( $field, $strict, $store );
+
+				return self::sanitize_code_editor_value( $value );
 			},
 			'client'        => array(
 				'control' => 'code_editor',
@@ -217,7 +225,9 @@ final class StructuredFieldTypes {
 				self::render_wp_editor_field( $field, $value, $field_name, $input_id, false, $name_template, $id_template );
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ): string {
-				return $store->sanitize_wp_editor_field( $value );
+				unset( $field, $strict, $store );
+
+				return self::sanitize_wp_editor_value( $value );
 			},
 			'client'        => array(
 				'control' => 'wp_editor',
@@ -484,6 +494,147 @@ final class StructuredFieldTypes {
 				array_map( 'absint', $ids )
 			)
 		);
+	}
+
+	/**
+	 * @param mixed $value
+	 * @return array<string, mixed>
+	 */
+	private static function sanitize_media_value( $value ): array {
+		$attachment_id = is_array( $value ) ? absint( $value['id'] ?? 0 ) : absint( $value );
+
+		if ( $attachment_id <= 0 ) {
+			return array();
+		}
+
+		$attachment_url = wp_get_attachment_url( $attachment_id );
+
+		if ( ! $attachment_url ) {
+			return array();
+		}
+
+		$thumbnail_url = wp_get_attachment_image_url( $attachment_id, 'thumbnail' );
+
+		return array_filter(
+			array(
+				'id'        => $attachment_id,
+				'url'       => $attachment_url,
+				'thumbnail' => $thumbnail_url ? $thumbnail_url : '',
+			)
+		);
+	}
+
+	/**
+	 * @param mixed $value
+	 * @return array<int, int>
+	 */
+	private static function sanitize_gallery_value( $value ): array {
+		return array_values( array_unique( self::normalize_gallery_ids( $value ) ) );
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 * @param mixed                $value
+	 * @return array<string, array<string, string>>
+	 */
+	private static function sanitize_sorter_value( array $field, $value, bool $strict ): array {
+		$choices = PageSchema::choices( $field );
+		$default = is_array( $field['default'] ?? null ) ? $field['default'] : array(
+			'enabled'  => array(),
+			'disabled' => array(),
+		);
+
+		if ( ! is_array( $value ) ) {
+			return $default;
+		}
+
+		$order   = array();
+		$enabled = array();
+
+		if ( array_key_exists( 'order', $value ) ) {
+			$order   = is_array( $value['order'] ?? null ) ? $value['order'] : array();
+			$enabled = is_array( $value['enabled'] ?? null ) ? $value['enabled'] : array();
+		} else {
+			$enabled  = array_keys( is_array( $value['enabled'] ?? null ) ? $value['enabled'] : array() );
+			$disabled = array_keys( is_array( $value['disabled'] ?? null ) ? $value['disabled'] : array() );
+			$order    = array_merge( $enabled, $disabled );
+		}
+
+		$ordered_keys = array();
+
+		foreach ( $order as $key ) {
+			$key = is_scalar( $key ) ? (string) $key : '';
+
+			if ( '' === $key || isset( $ordered_keys[ $key ] ) ) {
+				continue;
+			}
+
+			if ( $strict && ! array_key_exists( $key, $choices ) ) {
+				continue;
+			}
+
+			$ordered_keys[ $key ] = $key;
+		}
+
+		if ( ! $strict ) {
+			foreach ( array_keys( $choices ) as $key ) {
+				if ( ! isset( $ordered_keys[ $key ] ) ) {
+					$ordered_keys[ $key ] = $key;
+				}
+			}
+		}
+
+		if ( empty( $ordered_keys ) ) {
+			return $default;
+		}
+
+		$enabled_lookup = array();
+
+		foreach ( $enabled as $key ) {
+			$key = is_scalar( $key ) ? (string) $key : '';
+
+			if ( '' === $key ) {
+				continue;
+			}
+
+			if ( $strict && ! array_key_exists( $key, $choices ) ) {
+				continue;
+			}
+
+			$enabled_lookup[ $key ] = true;
+		}
+
+		$result = array(
+			'enabled'  => array(),
+			'disabled' => array(),
+		);
+
+		foreach ( $ordered_keys as $key ) {
+			$label = $choices[ $key ] ?? (string) $key;
+
+			if ( isset( $enabled_lookup[ $key ] ) ) {
+				$result['enabled'][ $key ] = $label;
+				continue;
+			}
+
+			$result['disabled'][ $key ] = $label;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	private static function sanitize_code_editor_value( $value ): string {
+		return PageSchema::scalar_value( $value, '', true );
+	}
+
+	/**
+	 * @param mixed $value
+	 */
+	private static function sanitize_wp_editor_value( $value ): string {
+		return wp_kses_post( PageSchema::scalar_value( $value ) );
 	}
 
 	private static function render_nested_warning( string $message ): void {

--- a/packages/AdminConfig/src/Framework/Storage/OptionStore.php
+++ b/packages/AdminConfig/src/Framework/Storage/OptionStore.php
@@ -580,38 +580,6 @@ final class OptionStore {
 	}
 
 	/**
-	 * Sanitize gallery fields as ordered attachment IDs.
-	 *
-	 * @param mixed $value Submitted value.
-	 * @return array<int, int>
-	 */
-	public function sanitize_gallery_field( $value ): array {
-		$ids = array();
-
-		if ( is_array( $value ) ) {
-			if ( isset( $value['ids'] ) && is_scalar( $value['ids'] ) ) {
-				$ids = explode( ',', (string) $value['ids'] );
-			} else {
-				$ids = $value;
-			}
-		} elseif ( is_scalar( $value ) ) {
-			$ids = explode( ',', (string) $value );
-		}
-
-		$clean = array();
-
-		foreach ( $ids as $id ) {
-			$id = absint( $id );
-
-			if ( $id > 0 ) {
-				$clean[] = $id;
-			}
-		}
-
-		return array_values( array_unique( $clean ) );
-	}
-
-	/**
 	 * Sanitize fieldsets into keyed arrays of sanitized child values.
 	 *
 	 * @param array<string, mixed> $field Field definition.
@@ -653,99 +621,6 @@ final class OptionStore {
 		}
 
 		return $clean;
-	}
-
-	/**
-	 * Sanitize sorter fields to the enabled/disabled legacy structure.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Submitted or stored value.
-	 * @return array<string, array<string, string>>
-	 */
-	public function sanitize_sorter_field( array $field, $value, bool $strict ): array {
-		$choices = PageSchema::choices( $field );
-		$default = is_array( $field['default'] ?? null ) ? $field['default'] : array(
-			'enabled'  => array(),
-			'disabled' => array(),
-		);
-
-		if ( ! is_array( $value ) ) {
-			return $default;
-		}
-
-		$order   = array();
-		$enabled = array();
-
-		if ( array_key_exists( 'order', $value ) ) {
-			$order   = is_array( $value['order'] ?? null ) ? $value['order'] : array();
-			$enabled = is_array( $value['enabled'] ?? null ) ? $value['enabled'] : array();
-		} else {
-			$enabled  = array_keys( is_array( $value['enabled'] ?? null ) ? $value['enabled'] : array() );
-			$disabled = array_keys( is_array( $value['disabled'] ?? null ) ? $value['disabled'] : array() );
-			$order    = array_merge( $enabled, $disabled );
-		}
-
-		$ordered_keys = array();
-
-		foreach ( $order as $key ) {
-			$key = is_scalar( $key ) ? (string) $key : '';
-
-			if ( '' === $key || isset( $ordered_keys[ $key ] ) ) {
-				continue;
-			}
-
-			if ( $strict && ! array_key_exists( $key, $choices ) ) {
-				continue;
-			}
-
-			$ordered_keys[ $key ] = $key;
-		}
-
-		if ( ! $strict ) {
-			foreach ( array_keys( $choices ) as $key ) {
-				if ( ! isset( $ordered_keys[ $key ] ) ) {
-					$ordered_keys[ $key ] = $key;
-				}
-			}
-		}
-
-		if ( empty( $ordered_keys ) ) {
-			return $default;
-		}
-
-		$enabled_lookup = array();
-
-		foreach ( $enabled as $key ) {
-			$key = is_scalar( $key ) ? (string) $key : '';
-
-			if ( '' === $key ) {
-				continue;
-			}
-
-			if ( $strict && ! array_key_exists( $key, $choices ) ) {
-				continue;
-			}
-
-			$enabled_lookup[ $key ] = true;
-		}
-
-		$result = array(
-			'enabled'  => array(),
-			'disabled' => array(),
-		);
-
-		foreach ( $ordered_keys as $key ) {
-			$label = $choices[ $key ] ?? (string) $key;
-
-			if ( isset( $enabled_lookup[ $key ] ) ) {
-				$result['enabled'][ $key ] = $label;
-				continue;
-			}
-
-			$result['disabled'][ $key ] = $label;
-		}
-
-		return $result;
 	}
 
 	/**
@@ -1053,53 +928,5 @@ final class OptionStore {
 			: '';
 
 		return '' !== $option_name ? $option_name : 'options_framework';
-	}
-
-	/**
-	 * @param mixed $value Submitted value.
-	 * @return array<string, mixed>
-	 */
-	public function sanitize_media_field( $value ): array {
-		$attachment_id = 0;
-
-		if ( is_array( $value ) ) {
-			$attachment_id = absint( $value['id'] ?? 0 );
-		} else {
-			$attachment_id = absint( $value );
-		}
-
-		if ( $attachment_id <= 0 ) {
-			return array();
-		}
-
-		$attachment_url = wp_get_attachment_url( $attachment_id );
-
-		if ( ! $attachment_url ) {
-			return array();
-		}
-
-		$thumbnail_url = wp_get_attachment_image_url( $attachment_id, 'thumbnail' );
-
-		return array_filter(
-			array(
-				'id'        => $attachment_id,
-				'url'       => $attachment_url,
-				'thumbnail' => $thumbnail_url ? $thumbnail_url : '',
-			)
-		);
-	}
-
-	/**
-	 * @param mixed $value Submitted value.
-	 */
-	public function sanitize_code_editor_field( $value ): string {
-		return is_scalar( $value ) ? trim( (string) $value ) : '';
-	}
-
-	/**
-	 * @param mixed $value Submitted value.
-	 */
-	public function sanitize_wp_editor_field( $value ): string {
-		return wp_kses_post( $this->string_value( $value ) );
 	}
 }

--- a/packages/AdminConfig/tests/Unit/StructuredFieldSanitizersTest.php
+++ b/packages/AdminConfig/tests/Unit/StructuredFieldSanitizersTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Structured field sanitizer tests.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\Tests\Unit;
+
+use Lerm\AdminConfig\Framework\FieldTypes\FieldTypeRegistry;
+use Lerm\AdminConfig\Framework\FieldTypes\StructuredFieldTypes;
+use Lerm\AdminConfig\Framework\Storage\OptionStore;
+use Lerm\AdminConfig\Tests\Support\TestCase;
+
+final class StructuredFieldSanitizersTest extends TestCase {
+
+	public function testMediaSanitizerReturnsAttachmentPayload(): void {
+		$store = $this->store();
+		$field = array(
+			'id'   => 'hero_image',
+			'type' => 'media',
+		);
+
+		$this->assertSame(
+			array(
+				'id'        => 42,
+				'url'       => 'https://example.test/uploads/full/42.jpg',
+				'thumbnail' => 'https://example.test/uploads/thumbnail/42.jpg',
+			),
+			$store->sanitize_field( $field, array( 'id' => 42 ) )
+		);
+	}
+
+	public function testGallerySanitizerDeduplicatesAndFiltersIds(): void {
+		$store = $this->store();
+		$field = array(
+			'id'   => 'gallery_items',
+			'type' => 'gallery',
+		);
+
+		$this->assertSame(
+			array( 3, 5, 8 ),
+			$store->sanitize_field( $field, array( 'ids' => '3,5,3,0,foo,8' ) )
+		);
+	}
+
+	public function testSorterSanitizerNormalizesLegacyPayloadIntoEnabledDisabledMaps(): void {
+		$store = $this->store();
+		$field = array(
+			'id'      => 'layout_sort',
+			'type'    => 'sorter',
+			'choices' => array(
+				'header'  => 'Header',
+				'sidebar' => 'Sidebar',
+				'footer'  => 'Footer',
+			),
+		);
+
+		$this->assertSame(
+			array(
+				'enabled'  => array(
+					'header' => 'Header',
+				),
+				'disabled' => array(
+					'footer' => 'Footer',
+				),
+			),
+			$store->sanitize_field(
+				$field,
+				array(
+					'enabled'  => array(
+						'header' => 'Header',
+					),
+					'disabled' => array(
+						'footer' => 'Footer',
+					),
+				)
+			)
+		);
+	}
+
+	public function testCodeEditorSanitizerTrimsScalarValues(): void {
+		$store = $this->store();
+		$field = array(
+			'id'   => 'custom_css',
+			'type' => 'code_editor',
+		);
+
+		$this->assertSame( 'body { color: red; }', $store->sanitize_field( $field, " \nbody { color: red; } \t" ) );
+		$this->assertSame( '', $store->sanitize_field( $field, array( 'not-scalar' ) ) );
+	}
+
+	public function testWpEditorSanitizerNormalizesScalarHtml(): void {
+		$store = $this->store();
+		$field = array(
+			'id'   => 'body_copy',
+			'type' => 'wp_editor',
+		);
+
+		$this->assertSame( '<p>Hello</p>', $store->sanitize_field( $field, '<p>Hello</p>' ) );
+		$this->assertSame( '', $store->sanitize_field( $field, array( 'not-scalar' ) ) );
+	}
+
+	private function store(): OptionStore {
+		$field_types = new FieldTypeRegistry();
+
+		foreach ( StructuredFieldTypes::definitions() as $type => $definition ) {
+			$field_types->register( (string) $type, $definition );
+		}
+
+		return new OptionStore(
+			array(
+				'id'    => 'unit_structured_field_sanitizers',
+				'store' => array(
+					'type' => 'option',
+					'key'  => 'unit_structured_field_sanitizers',
+				),
+			),
+			$field_types
+		);
+	}
+}

--- a/packages/AdminConfig/tests/bootstrap.php
+++ b/packages/AdminConfig/tests/bootstrap.php
@@ -418,6 +418,22 @@ if ( ! function_exists( 'wp_get_attachment_image_url' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_get_attachment_url' ) ) {
+	function wp_get_attachment_url( int $attachment_id ) {
+		if ( $attachment_id <= 0 ) {
+			return false;
+		}
+
+		return 'https://example.test/uploads/full/' . (string) $attachment_id . '.jpg';
+	}
+}
+
+if ( ! function_exists( 'wp_kses_post' ) ) {
+	function wp_kses_post( $content ): string {
+		return is_scalar( $content ) ? (string) $content : '';
+	}
+}
+
 if ( ! function_exists( 'wp_editor' ) ) {
 	function wp_editor( string $content, string $editor_id, array $settings = array() ): void {
 		$textarea_name = is_scalar( $settings['textarea_name'] ?? null ) ? (string) $settings['textarea_name'] : $editor_id;


### PR DESCRIPTION
## Summary
- move low-risk structured field sanitizers out of OptionStore and into StructuredFieldTypes
- add focused unit coverage for media, gallery, sorter, code editor, and wp editor sanitize flows
- extend the package test bootstrap with attachment and wp_kses_post stubs used by the new tests

## Verification
- composer ci
- npm run check:phase2
- git diff --check -- packages/AdminConfig