### PR TITLE
Move submission and sanitize rules into field metadata

### DIFF
--- a/packages/AdminConfig/CHANGELOG.md
+++ b/packages/AdminConfig/CHANGELOG.md
@@ -96,6 +96,11 @@ The format follows Keep a Changelog and the package uses Semantic Versioning onc
 - Low-risk structured field sanitizers for media, gallery, sorter, code
   editor, and WordPress editor fields now live in structured field type
   definitions instead of `OptionStore`.
+- Missing-submission retry handling for multi-select, checkbox-list,
+  checkbox-choice, and group fields now comes from field type metadata instead
+  of `OptionsPage` hardcoded type checks.
+- `OptionStore` no longer carries duplicate `select` and `number` fallback
+  sanitizers once core field definitions are registered.
 - PHPStan now runs with a 2G default memory limit, overridable through
   `LERM_ADMIN_CONFIG_PHPSTAN_MEMORY_LIMIT`, to keep local and CI analysis
   stable as package coverage grows.

--- a/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
+++ b/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
@@ -915,8 +915,6 @@ final class OptionsPage {
 	 * @return array{apply: bool, value: mixed}
 	 */
 	private function missing_submission_render_value( array $field ): array {
-		$type = sanitize_key( (string) ( $field['type'] ?? 'text' ) );
-
 		if ( array_key_exists( 'missing_submission_value', $field ) ) {
 			return array(
 				'apply' => true,
@@ -924,25 +922,18 @@ final class OptionsPage {
 			);
 		}
 
-		if ( 'select' === $type && ! empty( $field['multiple'] ) ) {
-			return array(
-				'apply' => true,
-				'value' => array(),
-			);
-		}
+		$type     = sanitize_key( (string) ( $field['type'] ?? 'text' ) );
+		$callback = $this->field_types->missing_submission_callback( $type );
 
-		if ( 'checkbox_list' === $type || 'group' === $type ) {
-			return array(
-				'apply' => true,
-				'value' => array(),
-			);
-		}
+		if ( is_callable( $callback ) ) {
+			$missing = call_user_func( $callback, $field );
 
-		if ( 'checkbox' === $type && ! empty( PageSchema::choices( $field ) ) ) {
-			return array(
-				'apply' => true,
-				'value' => array(),
-			);
+			if ( is_array( $missing ) ) {
+				return array(
+					'apply' => ! empty( $missing['apply'] ),
+					'value' => $missing['value'] ?? null,
+				);
+			}
 		}
 
 		return array(

--- a/packages/AdminConfig/src/Framework/FieldTypes/BuiltinFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/BuiltinFieldTypes.php
@@ -279,16 +279,29 @@ final class BuiltinFieldTypes {
 	 */
 	private static function select_definition(): array {
 		return array(
-			'render'        => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
+			'render'             => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
 				self::render_select( $field, $value, $field_name, (string) $field['id'], true );
 			},
-			'render_nested' => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ): void {
+			'render_nested'      => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ): void {
 				self::render_select( $field, $value, $field_name, $input_id, false, $name_template, $id_template );
 			},
-			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
+			'sanitize'           => static function ( array $field, $value, bool $strict, OptionStore $store ) {
 				return self::sanitize_select_like( $field, $value, $strict );
 			},
-			'client'        => array(
+			'missing_submission' => static function ( array $field ): array {
+				if ( empty( $field['multiple'] ) ) {
+					return array(
+						'apply' => false,
+						'value' => null,
+					);
+				}
+
+				return array(
+					'apply' => true,
+					'value' => array(),
+				);
+			},
+			'client'             => array(
 				'control' => 'select',
 				'nested'  => true,
 			),
@@ -300,16 +313,22 @@ final class BuiltinFieldTypes {
 	 */
 	private static function checkbox_list_definition(): array {
 		return array(
-			'render'        => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
+			'render'             => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
 				self::render_checkbox_list( $field, $value, $field_name, true, '', $page->dependency_controller_attribute( $field ) );
 			},
-			'render_nested' => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ): void {
+			'render_nested'      => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ): void {
 				self::render_checkbox_list( $field, $value, $field_name, false, $name_template );
 			},
-			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
+			'sanitize'           => static function ( array $field, $value, bool $strict, OptionStore $store ) {
 				return self::sanitize_checkbox_list( $field, $value, $strict );
 			},
-			'client'        => array(
+			'missing_submission' => static function (): array {
+				return array(
+					'apply' => true,
+					'value' => array(),
+				);
+			},
+			'client'             => array(
 				'control' => 'checkbox_list',
 				'nested'  => true,
 			),

--- a/packages/AdminConfig/src/Framework/FieldTypes/ExtendedPrimitiveFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/ExtendedPrimitiveFieldTypes.php
@@ -42,7 +42,7 @@ final class ExtendedPrimitiveFieldTypes {
 	 */
 	private static function checkbox_definition(): array {
 		return array(
-			'render'        => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
+			'render'             => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
 				if ( self::checkbox_uses_choices( $field ) ) {
 					self::render_checkbox_group( $field, $value, $field_name, true, $page->dependency_controller_attribute( $field ) );
 					return;
@@ -56,7 +56,7 @@ final class ExtendedPrimitiveFieldTypes {
 					$page->dependency_controller_attribute( $field )
 				);
 			},
-			'render_nested' => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ): void {
+			'render_nested'      => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ): void {
 				if ( self::checkbox_uses_choices( $field ) ) {
 					self::render_checkbox_group( $field, $value, $field_name, false, self::name_attr( self::multiple_name_template( $name_template ) ) );
 					return;
@@ -72,14 +72,27 @@ final class ExtendedPrimitiveFieldTypes {
 					self::id_attr( $id_template )
 				);
 			},
-			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
+			'sanitize'           => static function ( array $field, $value, bool $strict, OptionStore $store ) {
 				if ( self::checkbox_uses_choices( $field ) ) {
 					return self::sanitize_checkbox_choices( $field, $value, $strict );
 				}
 
 				return ! empty( $value );
 			},
-			'client'        => array(
+			'missing_submission' => static function ( array $field ): array {
+				if ( ! self::checkbox_uses_choices( $field ) ) {
+					return array(
+						'apply' => false,
+						'value' => null,
+					);
+				}
+
+				return array(
+					'apply' => true,
+					'value' => array(),
+				);
+			},
+			'client'             => array(
 				'control' => 'checkbox',
 				'nested'  => true,
 			),

--- a/packages/AdminConfig/src/Framework/FieldTypes/FieldTypeRegistry.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/FieldTypeRegistry.php
@@ -53,14 +53,15 @@ final class FieldTypeRegistry {
 		$this->types[ $type ] = wp_parse_args(
 			$definition,
 			array(
-				'render'        => null,
-				'render_nested' => null,
-				'sanitize'      => null,
-				'validate'      => null,
-				'serialize'     => null,
-				'client'        => array(),
-				'persist'       => true,
-				'builtin'       => false,
+				'render'             => null,
+				'render_nested'      => null,
+				'sanitize'           => null,
+				'missing_submission' => null,
+				'validate'           => null,
+				'serialize'          => null,
+				'client'             => array(),
+				'persist'            => true,
+				'builtin'            => false,
 			)
 		);
 	}
@@ -129,6 +130,21 @@ final class FieldTypeRegistry {
 		}
 
 		return $this->types[ $type ]['sanitize'];
+	}
+
+	/**
+	 * Return the missing-submission callback for a field type.
+	 *
+	 * @return callable|null
+	 */
+	public function missing_submission_callback( string $type ): ?callable {
+		$type = sanitize_key( $type );
+
+		if ( ! isset( $this->types[ $type ]['missing_submission'] ) || ! is_callable( $this->types[ $type ]['missing_submission'] ) ) {
+			return null;
+		}
+
+		return $this->types[ $type ]['missing_submission'];
 	}
 
 	/**

--- a/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
@@ -77,13 +77,19 @@ final class StructuredFieldTypes {
 	 */
 	private static function group_definition(): array {
 		return array(
-			'render'   => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
+			'render'             => static function ( array $field, $value, string $field_name, OptionsPage $page ): void {
 				$page->container_field_renderer()->render_group( $field, $value, $field_name );
 			},
-			'sanitize' => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
+			'sanitize'           => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
 				return $store->sanitize_group_field( $field, $value, $strict );
 			},
-			'client'   => array(
+			'missing_submission' => static function (): array {
+				return array(
+					'apply' => true,
+					'value' => array(),
+				);
+			},
+			'client'             => array(
 				'control' => 'group',
 			),
 		);

--- a/packages/AdminConfig/src/Framework/Storage/OptionStore.php
+++ b/packages/AdminConfig/src/Framework/Storage/OptionStore.php
@@ -425,41 +425,6 @@ final class OptionStore {
 						$value = esc_url_raw( $this->string_value( $value, '', true ) );
 						break;
 
-					case 'button_set':
-					case 'radio':
-					case 'select':
-						$value = $this->sanitize_select_field( $field, $value, $strict );
-						break;
-
-					case 'checkbox_list':
-						$choices = $strict ? PageSchema::choices( $field ) : array();
-						$values  = is_array( $value ) ? $value : array();
-						$clean   = array();
-
-						foreach ( $values as $item ) {
-							$item = is_scalar( $item ) ? (string) $item : '';
-
-							if ( '' === $item ) {
-								continue;
-							}
-
-							if ( ! $strict ) {
-								$clean[] = $item;
-								continue;
-							}
-
-							if ( array_key_exists( $item, $choices ) ) {
-								$clean[] = $item;
-							}
-						}
-
-						$value = array_values( array_unique( $clean ) );
-						break;
-
-					case 'number':
-						$value = $this->sanitize_number_field( $field, $value, $default );
-						break;
-
 					case 'textarea':
 						$value = sanitize_textarea_field( $this->string_value( $value ) );
 						break;
@@ -624,82 +589,6 @@ final class OptionStore {
 	}
 
 	/**
-	 * Sanitize select-like fields, including multi-select payloads.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Submitted value.
-	 * @return mixed
-	 */
-	private function sanitize_select_field( array $field, $value, bool $strict ) {
-		$default  = $field['default'] ?? '';
-		$cast     = (string) ( $field['cast'] ?? '' );
-		$multiple = ! empty( $field['multiple'] );
-
-		if ( $multiple ) {
-			$values  = is_array( $value ) ? $value : array();
-			$choices = $strict ? PageSchema::choices( $field ) : array();
-			$clean   = array();
-
-			foreach ( $values as $item ) {
-				$item = is_scalar( $item ) ? (string) $item : '';
-
-				if ( '' === $item ) {
-					continue;
-				}
-
-				if ( $strict && ! array_key_exists( $item, $choices ) ) {
-					continue;
-				}
-
-				$clean[] = $this->cast_scalar_value( $item, $cast );
-			}
-
-			return array_values( array_unique( $clean, SORT_REGULAR ) );
-		}
-
-		$choice = is_scalar( $value ) ? (string) $value : '';
-
-		if ( $strict ) {
-			$choices = PageSchema::choices( $field );
-
-			if ( ! array_key_exists( $choice, $choices ) ) {
-				return $default;
-			}
-		}
-
-		return $this->cast_scalar_value( $choice, $cast );
-	}
-
-	/**
-	 * Sanitize numeric fields while preserving optional float support.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Submitted value.
-	 * @param mixed                $fallback Default value.
-	 * @return int|float
-	 */
-	private function sanitize_number_field( array $field, $value, $fallback ) {
-		$cast   = (string) ( $field['cast'] ?? 'int' );
-		$number = is_numeric( $value ) ? (float) $value : (float) $fallback;
-		$min    = isset( $field['min'] ) && is_numeric( $field['min'] ) ? (float) $field['min'] : null;
-		$max    = isset( $field['max'] ) && is_numeric( $field['max'] ) ? (float) $field['max'] : null;
-
-		if ( null !== $min && $number < $min ) {
-			$number = $min;
-		}
-
-		if ( null !== $max && $number > $max ) {
-			$number = $max;
-		}
-
-		if ( 'float' === $cast ) {
-			return $number;
-		}
-
-		return (int) round( $number );
-	}
-
-	/**
 	 * Sanitize nested child field definitions.
 	 *
 	 * @param array<int, array<string, mixed>> $fields Child fields.
@@ -845,24 +734,6 @@ final class OptionStore {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Cast scalar values according to field preferences.
-	 *
-	 * @param string $value Scalar value.
-	 * @return string|int|float
-	 */
-	private function cast_scalar_value( string $value, string $cast ) {
-		if ( 'int' === $cast ) {
-			return (int) $value;
-		}
-
-		if ( 'float' === $cast ) {
-			return (float) $value;
-		}
-
-		return $value;
 	}
 
 	/**

--- a/packages/AdminConfig/tests/Unit/BuiltinFieldSanitizersTest.php
+++ b/packages/AdminConfig/tests/Unit/BuiltinFieldSanitizersTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Built-in field sanitizer tests.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\Tests\Unit;
+
+use Lerm\AdminConfig\Framework\FieldTypes\BuiltinFieldTypes;
+use Lerm\AdminConfig\Framework\FieldTypes\FieldTypeRegistry;
+use Lerm\AdminConfig\Framework\Storage\OptionStore;
+use Lerm\AdminConfig\Tests\Support\TestCase;
+
+final class BuiltinFieldSanitizersTest extends TestCase {
+
+	public function testSelectSanitizerUsesFieldDefinitionForMultipleChoices(): void {
+		$store = $this->store();
+		$field = array(
+			'id'       => 'columns',
+			'type'     => 'select',
+			'multiple' => true,
+			'cast'     => 'int',
+			'choices'  => array(
+				'1' => 'One',
+				'2' => 'Two',
+				'3' => 'Three',
+			),
+			'default'  => array(),
+		);
+
+		$this->assertSame(
+			array( 2, 3 ),
+			$store->sanitize_field( $field, array( '2', '3', '9', '2', 'foo' ) )
+		);
+	}
+
+	public function testNumberSanitizerUsesFieldDefinitionForClampAndFloatSupport(): void {
+		$store = $this->store();
+
+		$this->assertSame(
+			4,
+			$store->sanitize_field(
+				array(
+					'id'      => 'count',
+					'type'    => 'number',
+					'cast'    => 'int',
+					'min'     => 1,
+					'max'     => 4,
+					'default' => 2,
+				),
+				'5.6'
+			)
+		);
+
+		$this->assertSame(
+			1.75,
+			$store->sanitize_field(
+				array(
+					'id'      => 'ratio',
+					'type'    => 'number',
+					'cast'    => 'float',
+					'min'     => 0.5,
+					'max'     => 2.5,
+					'default' => 1.0,
+				),
+				'1.75'
+			)
+		);
+	}
+
+	private function store(): OptionStore {
+		$field_types = new FieldTypeRegistry();
+
+		foreach ( BuiltinFieldTypes::definitions() as $type => $definition ) {
+			$field_types->register( (string) $type, $definition );
+		}
+
+		return new OptionStore(
+			array(
+				'id'    => 'unit_builtin_field_sanitizers',
+				'store' => array(
+					'type' => 'option',
+					'key'  => 'unit_builtin_field_sanitizers',
+				),
+			),
+			$field_types
+		);
+	}
+}

--- a/packages/AdminConfig/tests/Unit/OptionsPageSubmissionStateTest.php
+++ b/packages/AdminConfig/tests/Unit/OptionsPageSubmissionStateTest.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Options page submission state tests.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\Tests\Unit;
+
+use Lerm\AdminConfig\Framework\Admin\OptionsPage;
+use Lerm\AdminConfig\Framework\Contracts\AssetResolver;
+use Lerm\AdminConfig\Framework\FieldTypes\BuiltinFieldTypes;
+use Lerm\AdminConfig\Framework\FieldTypes\ExtendedPrimitiveFieldTypes;
+use Lerm\AdminConfig\Framework\FieldTypes\FieldTypeRegistry;
+use Lerm\AdminConfig\Framework\FieldTypes\StructuredFieldTypes;
+use Lerm\AdminConfig\Framework\Storage\OptionStore;
+use Lerm\AdminConfig\Tests\Support\TestCase;
+
+final class OptionsPageSubmissionStateTest extends TestCase {
+
+	public function testMissingSubmissionRulesComeFromFieldTypeMetadata(): void {
+		$definition = array(
+			'id'       => 'unit_missing_submission_state',
+			'store'    => array(
+				'type' => 'option',
+				'key'  => 'unit_missing_submission_state',
+			),
+			'sections' => array(
+				'general' => array(
+					'fields' => array(
+						array(
+							'id'       => 'channels',
+							'type'     => 'select',
+							'multiple' => true,
+							'choices'  => array(
+								'news' => 'News',
+								'blog' => 'Blog',
+							),
+						),
+						array(
+							'id'      => 'audiences',
+							'type'    => 'checkbox_list',
+							'choices' => array(
+								'members' => 'Members',
+								'guests'  => 'Guests',
+							),
+						),
+						array(
+							'id'      => 'flags',
+							'type'    => 'checkbox',
+							'choices' => array(
+								'beta' => 'Beta',
+							),
+						),
+						array(
+							'id'     => 'cards',
+							'type'   => 'group',
+							'fields' => array(
+								array(
+									'id'   => 'title',
+									'type' => 'text',
+								),
+							),
+						),
+						array(
+							'id'      => 'tone',
+							'type'    => 'select',
+							'choices' => array(
+								'calm' => 'Calm',
+								'bold' => 'Bold',
+							),
+						),
+						array(
+							'id'                       => 'slug',
+							'type'                     => 'text',
+							'missing_submission_value' => 'untitled',
+						),
+						array(
+							'id'   => 'headline',
+							'type' => 'text',
+						),
+					),
+				),
+			),
+		);
+		$page       = $this->options_page( $definition );
+		$merged     = $this->merge_section_submitted_values(
+			$page,
+			'general',
+			array(
+				'channels'  => array( 'news' ),
+				'audiences' => array( 'members' ),
+				'flags'     => array( 'beta' ),
+				'cards'     => array(
+					array(
+						'title' => 'Existing card',
+					),
+				),
+				'tone'      => 'calm',
+				'slug'      => 'existing-slug',
+				'headline'  => 'Saved headline',
+			),
+			array(
+				'headline' => 'Draft headline',
+			)
+		);
+
+		$this->assertSame( array(), $merged['channels'] );
+		$this->assertSame( array(), $merged['audiences'] );
+		$this->assertSame( array(), $merged['flags'] );
+		$this->assertSame( array(), $merged['cards'] );
+		$this->assertSame( 'calm', $merged['tone'] );
+		$this->assertSame( 'untitled', $merged['slug'] );
+		$this->assertSame( 'Draft headline', $merged['headline'] );
+	}
+
+	/**
+	 * @param array<string, mixed> $definition
+	 */
+	private function options_page( array $definition ): OptionsPage {
+		$field_types = new FieldTypeRegistry();
+
+		foreach ( array_merge( BuiltinFieldTypes::definitions(), ExtendedPrimitiveFieldTypes::definitions(), StructuredFieldTypes::definitions() ) as $type => $field_type_definition ) {
+			$field_types->register( (string) $type, $field_type_definition );
+		}
+
+		$store    = new OptionStore( $definition, $field_types );
+		$resolver = new class() implements AssetResolver {
+			public function url( string $filename ): string {
+				return 'https://example.test/assets/' . ltrim( $filename, '/' );
+			}
+
+			public function version(): string {
+				return 'unit-version';
+			}
+		};
+
+		return new OptionsPage( $definition, $store, $field_types, $resolver, false );
+	}
+
+	/**
+	 * @param array<string, mixed> $values
+	 * @param array<string, mixed> $submitted
+	 * @return array<string, mixed>
+	 */
+	private function merge_section_submitted_values( OptionsPage $page, string $section_id, array $values, array $submitted ): array {
+		$method = new \ReflectionMethod( $page, 'merge_section_submitted_values' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $page, $section_id, $values, $submitted );
+
+		return is_array( $result ) ? $result : array();
+	}
+}


### PR DESCRIPTION
## Summary
- register missing-submission callbacks on built-in, extended, and structured field definitions
- remove duplicate select and number fallback sanitizers from OptionStore
- add focused unit coverage for built-in sanitizer behavior and validation-retry submission state replay

## Verification
- composer ci
- npm run check:phase2
- git diff --check -- packages/AdminConfig