### PR TITLE
Extract nested container sanitizers

### DIFF
--- a/packages/AdminConfig/CHANGELOG.md
+++ b/packages/AdminConfig/CHANGELOG.md
@@ -101,6 +101,9 @@ The format follows Keep a Changelog and the package uses Semantic Versioning onc
   of `OptionsPage` hardcoded type checks.
 - `OptionStore` no longer carries duplicate `select` and `number` fallback
   sanitizers once core field definitions are registered.
+- Nested `fieldset`, `group`, `typography`, `accordion`, and `tabbed`
+  sanitization now lives in shared field-type helpers instead of
+  `OptionStore` field-type-specific methods.
 - PHPStan now runs with a 2G default memory limit, overridable through
   `LERM_ADMIN_CONFIG_PHPSTAN_MEMORY_LIMIT`, to keep local and CI analysis
   stable as package coverage grows.

--- a/packages/AdminConfig/src/Framework/FieldTypes/AdvancedFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/AdvancedFieldTypes.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Lerm\AdminConfig\Framework\FieldTypes;
 
 use Lerm\AdminConfig\Framework\Admin\OptionsPage;
+use Lerm\AdminConfig\Framework\FieldTypes\Support\NestedFieldSanitizer;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
 use Lerm\AdminConfig\Framework\Support\PageSchema;
 
@@ -40,7 +41,7 @@ final class AdvancedFieldTypes {
 				$page->container_field_renderer()->render_fieldset( self::typography_field( $field ), $value, $field_name );
 			},
 			'sanitize' => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
-				return $store->sanitize_fieldset_field( self::typography_field( $field ), $value, $strict );
+				return NestedFieldSanitizer::sanitize_fieldset( self::typography_field( $field ), $value, $strict, $store );
 			},
 			'client'   => array(
 				'control' => 'typography',
@@ -205,13 +206,14 @@ final class AdvancedFieldTypes {
 			$item_id           = (string) $item['id'];
 			$item_fields       = is_array( $item['fields'] ?? null ) ? $item['fields'] : array();
 			$item_value        = is_array( $values[ $item_id ] ?? null ) ? $values[ $item_id ] : array();
-			$clean[ $item_id ] = $store->sanitize_fieldset_field(
+			$clean[ $item_id ] = NestedFieldSanitizer::sanitize_fieldset(
 				array(
 					'id'     => $item_id,
 					'fields' => $item_fields,
 				),
 				$item_value,
-				$strict
+				$strict,
+				$store
 			);
 		}
 

--- a/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Lerm\AdminConfig\Framework\FieldTypes;
 
 use Lerm\AdminConfig\Framework\Admin\OptionsPage;
+use Lerm\AdminConfig\Framework\FieldTypes\Support\NestedFieldSanitizer;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
 use Lerm\AdminConfig\Framework\Support\PageSchema;
 
@@ -64,7 +65,7 @@ final class StructuredFieldTypes {
 				$page->container_field_renderer()->render_fieldset( $field, $value, $field_name );
 			},
 			'sanitize' => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
-				return $store->sanitize_fieldset_field( $field, $value, $strict );
+				return NestedFieldSanitizer::sanitize_fieldset( $field, $value, $strict, $store );
 			},
 			'client'   => array(
 				'control' => 'fieldset',
@@ -81,7 +82,7 @@ final class StructuredFieldTypes {
 				$page->container_field_renderer()->render_group( $field, $value, $field_name );
 			},
 			'sanitize'           => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
-				return $store->sanitize_group_field( $field, $value, $strict );
+				return NestedFieldSanitizer::sanitize_group( $field, $value, $strict, $store );
 			},
 			'missing_submission' => static function (): array {
 				return array(

--- a/packages/AdminConfig/src/Framework/FieldTypes/Support/NestedFieldSanitizer.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/Support/NestedFieldSanitizer.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Shared nested container sanitization helpers.
+ *
+ * @package Lerm
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\Framework\FieldTypes\Support;
+
+use Lerm\AdminConfig\Framework\Storage\OptionStore;
+use Lerm\AdminConfig\Framework\Support\PageSchema;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class NestedFieldSanitizer {
+
+	/**
+	 * @param array<string, mixed> $field
+	 * @param mixed                $value
+	 * @return array<string, mixed>
+	 */
+	public static function sanitize_fieldset( array $field, $value, bool $strict, OptionStore $store, string $base_path = '' ): array {
+		$fields = is_array( $field['fields'] ?? null ) ? $field['fields'] : array();
+		$data   = is_array( $value ) ? $value : array();
+
+		return self::sanitize_child_fields( $fields, $data, $strict, $store, $store->field_container_path( $field, $base_path ) );
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 * @param mixed                $value
+	 * @return array<int, array<string, mixed>>
+	 */
+	public static function sanitize_group( array $field, $value, bool $strict, OptionStore $store, string $base_path = '' ): array {
+		$fields = is_array( $field['fields'] ?? null ) ? $field['fields'] : array();
+		$items  = is_array( $value ) ? array_values( $value ) : array();
+		$clean  = array();
+		$path   = $store->field_container_path( $field, $base_path );
+
+		foreach ( $items as $index => $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			$sanitized = self::sanitize_child_fields( $fields, $item, $strict, $store, self::compose_path( $path, (string) $index ) );
+
+			if ( self::nested_values_empty( $sanitized ) ) {
+				continue;
+			}
+
+			$clean[] = $sanitized;
+		}
+
+		return $clean;
+	}
+
+	/**
+	 * @param array<int, array<string, mixed>> $fields
+	 * @param array<string, mixed>             $submitted
+	 * @return array<string, mixed>
+	 */
+	private static function sanitize_child_fields( array $fields, array $submitted, bool $strict, OptionStore $store, string $base_path = '' ): array {
+		$clean = array();
+
+		foreach ( $fields as $child ) {
+			if ( ! is_array( $child ) || ! isset( $child['id'] ) ) {
+				continue;
+			}
+
+			$child_id           = (string) $child['id'];
+			$clean[ $child_id ] = $store->sanitize_nested_field(
+				$child,
+				$submitted[ $child_id ] ?? null,
+				$strict,
+				self::compose_path( $base_path, $child_id )
+			);
+		}
+
+		return $clean;
+	}
+
+	private static function compose_path( string $base_path, string $segment ): string {
+		if ( '' === $segment ) {
+			return $base_path;
+		}
+
+		if ( '' === $base_path ) {
+			return $segment;
+		}
+
+		return $base_path . '.' . $segment;
+	}
+
+	/**
+	 * @param array<string, mixed> $values
+	 */
+	private static function nested_values_empty( array $values ): bool {
+		foreach ( $values as $value ) {
+			if ( is_array( $value ) ) {
+				if ( ! empty( $value ) && ! self::nested_values_empty( $value ) ) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if ( is_bool( $value ) ) {
+				if ( $value ) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if ( '' !== PageSchema::scalar_value( $value, '', true ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/packages/AdminConfig/src/Framework/Storage/OptionStore.php
+++ b/packages/AdminConfig/src/Framework/Storage/OptionStore.php
@@ -458,6 +458,22 @@ final class OptionStore {
 	}
 
 	/**
+	 * @param array<string, mixed> $field
+	 * @param mixed                $value
+	 * @return mixed
+	 */
+	public function sanitize_nested_field( array $field, $value, bool $strict, string $path ) {
+		return $this->sanitize_field_internal( $field, $value, $strict, $path );
+	}
+
+	/**
+	 * @param array<string, mixed> $field
+	 */
+	public function field_container_path( array $field, string $base_path = '' ): string {
+		return $this->container_path( $field, $base_path );
+	}
+
+	/**
 	 * Run an optional field-level validator after sanitization.
 	 *
 	 * Validators should return the validated value. Returning WP_Error records
@@ -542,77 +558,6 @@ final class OptionStore {
 		$this->raw_options        = $previous;
 		$this->normalized_options = null;
 		return false;
-	}
-
-	/**
-	 * Sanitize fieldsets into keyed arrays of sanitized child values.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Submitted value.
-	 * @return array<string, mixed>
-	 */
-	public function sanitize_fieldset_field( array $field, $value, bool $strict, string $base_path = '' ): array {
-		$fields = is_array( $field['fields'] ?? null ) ? $field['fields'] : array();
-		$data   = is_array( $value ) ? $value : array();
-
-		return $this->sanitize_nested_fields( $fields, $data, $strict, $this->container_path( $field, $base_path ) );
-	}
-
-	/**
-	 * Sanitize repeatable group fields.
-	 *
-	 * @param array<string, mixed> $field Field definition.
-	 * @param mixed                $value Submitted value.
-	 * @return array<int, array<string, mixed>>
-	 */
-	public function sanitize_group_field( array $field, $value, bool $strict, string $base_path = '' ): array {
-		$fields = is_array( $field['fields'] ?? null ) ? $field['fields'] : array();
-		$items  = is_array( $value ) ? array_values( $value ) : array();
-		$clean  = array();
-		$path   = $this->container_path( $field, $base_path );
-
-		foreach ( $items as $index => $item ) {
-			if ( ! is_array( $item ) ) {
-				continue;
-			}
-
-			$sanitized = $this->sanitize_nested_fields( $fields, $item, $strict, $this->compose_path( $path, (string) $index ) );
-
-			if ( $this->nested_values_empty( $sanitized ) ) {
-				continue;
-			}
-
-			$clean[] = $sanitized;
-		}
-
-		return $clean;
-	}
-
-	/**
-	 * Sanitize nested child field definitions.
-	 *
-	 * @param array<int, array<string, mixed>> $fields Child fields.
-	 * @param array<string, mixed>             $submitted Submitted child values.
-	 * @return array<string, mixed>
-	 */
-	private function sanitize_nested_fields( array $fields, array $submitted, bool $strict, string $base_path = '' ): array {
-		$clean = array();
-
-		foreach ( $fields as $child ) {
-			if ( ! is_array( $child ) || ! isset( $child['id'] ) ) {
-				continue;
-			}
-
-			$child_id           = (string) $child['id'];
-			$clean[ $child_id ] = $this->sanitize_field_internal(
-				$child,
-				$submitted[ $child_id ] ?? null,
-				$strict,
-				$this->compose_path( $base_path, $child_id )
-			);
-		}
-
-		return $clean;
 	}
 
 	private function begin_validation_capture(): void {
@@ -703,37 +648,6 @@ final class OptionStore {
 
 			$this->validation_errors[ $path ][] = $message;
 		}
-	}
-
-	/**
-	 * Determine whether a nested group item only contains empty values.
-	 *
-	 * @param array<string, mixed> $values Nested values.
-	 */
-	private function nested_values_empty( array $values ): bool {
-		foreach ( $values as $value ) {
-			if ( is_array( $value ) ) {
-				if ( ! empty( $value ) && ! $this->nested_values_empty( $value ) ) {
-					return false;
-				}
-
-				continue;
-			}
-
-			if ( is_bool( $value ) ) {
-				if ( $value ) {
-					return false;
-				}
-
-				continue;
-			}
-
-			if ( '' !== $this->string_value( $value, '', true ) ) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	/**

--- a/packages/AdminConfig/tests/Unit/NestedFieldSanitizersTest.php
+++ b/packages/AdminConfig/tests/Unit/NestedFieldSanitizersTest.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Nested field sanitizer tests.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\Tests\Unit;
+
+use Lerm\AdminConfig\Framework\FieldTypes\AdvancedFieldTypes;
+use Lerm\AdminConfig\Framework\FieldTypes\BuiltinFieldTypes;
+use Lerm\AdminConfig\Framework\FieldTypes\FieldTypeRegistry;
+use Lerm\AdminConfig\Framework\FieldTypes\StructuredFieldTypes;
+use Lerm\AdminConfig\Framework\Storage\OptionStore;
+use Lerm\AdminConfig\Tests\Support\TestCase;
+
+final class NestedFieldSanitizersTest extends TestCase {
+
+	public function testFieldsetValidationErrorsKeepNestedPaths(): void {
+		$field_types = $this->field_types();
+		$field_types->register_validator(
+			'text',
+			static function ( array $field, $value ) {
+				unset( $field );
+
+				if ( '' === (string) $value ) {
+					return new \WP_Error( 'required', 'Value is required.' );
+				}
+
+				return $value;
+			}
+		);
+
+		$store = new OptionStore(
+			array(
+				'id'       => 'nested_fieldset_validation',
+				'sections' => array(
+					'general' => array(
+						'fields' => array(
+							array(
+								'id'     => 'layout',
+								'type'   => 'fieldset',
+								'fields' => array(
+									array(
+										'id'   => 'headline',
+										'type' => 'text',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+			$field_types
+		);
+
+		$this->assertFalse(
+			$store->save_all(
+				array(
+					'layout' => array(
+						'headline' => '',
+					),
+				)
+			)
+		);
+		$this->assertSame(
+			array(
+				'layout.headline' => array( 'Value is required.' ),
+			),
+			$store->validation_errors()
+		);
+	}
+
+	public function testGroupSanitizerDropsEmptyItems(): void {
+		$store = new OptionStore(
+			array(
+				'id'    => 'nested_group_sanitize',
+				'store' => array(
+					'type' => 'option',
+					'key'  => 'nested_group_sanitize',
+				),
+			),
+			$this->field_types()
+		);
+
+		$this->assertSame(
+			array(
+				array(
+					'title' => 'Primary card',
+				),
+			),
+			$store->sanitize_field(
+				array(
+					'id'     => 'cards',
+					'type'   => 'group',
+					'fields' => array(
+						array(
+							'id'   => 'title',
+							'type' => 'text',
+						),
+					),
+				),
+				array(
+					array(
+						'title' => '',
+					),
+					array(
+						'title' => 'Primary card',
+					),
+				)
+			)
+		);
+	}
+
+	public function testAccordionValidationErrorsKeepPerPanelPaths(): void {
+		$field_types = $this->field_types();
+		$field_types->register_validator(
+			'text',
+			static function ( array $field, $value ) {
+				unset( $field );
+
+				if ( '' === (string) $value ) {
+					return new \WP_Error( 'required', 'Value is required.' );
+				}
+
+				return $value;
+			}
+		);
+
+		$store = new OptionStore(
+			array(
+				'id'       => 'nested_panel_validation',
+				'sections' => array(
+					'general' => array(
+						'fields' => array(
+							array(
+								'id'    => 'launch_accordion',
+								'type'  => 'accordion',
+								'items' => array(
+									array(
+										'id'     => 'cta',
+										'title'  => 'CTA',
+										'fields' => array(
+											array(
+												'id'   => 'button_label',
+												'type' => 'text',
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+			$field_types
+		);
+
+		$this->assertFalse(
+			$store->save_all(
+				array(
+					'launch_accordion' => array(
+						'cta' => array(
+							'button_label' => '',
+						),
+					),
+				)
+			)
+		);
+		$this->assertSame(
+			array(
+				'launch_accordion.cta.button_label' => array( 'Value is required.' ),
+			),
+			$store->validation_errors()
+		);
+	}
+
+	private function field_types(): FieldTypeRegistry {
+		$field_types = new FieldTypeRegistry();
+
+		foreach ( array_merge( BuiltinFieldTypes::definitions(), StructuredFieldTypes::definitions(), AdvancedFieldTypes::definitions() ) as $type => $definition ) {
+			$field_types->register( (string) $type, $definition );
+		}
+
+		return $field_types;
+	}
+}


### PR DESCRIPTION
## Summary
- move fieldset, group, typography, accordion, and tabbed sanitization into a shared nested field-type helper
- reduce OptionStore to generic nested path and child-field sanitization entry points
- add focused unit coverage for nested validation paths and empty group-item filtering

## Verification
- composer ci
- npm run check:phase2
- git diff --check -- packages/AdminConfig