### PR TITLE
refactor: remove hardcoded theme path from Framework constructor

### DIFF
--- a/packages/AdminConfig/src/Framework/FieldTypes/FieldTypeRegistry.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/FieldTypeRegistry.php
@@ -38,16 +38,8 @@ final class FieldTypeRegistry {
 		$current = $this->types[ $type ] ?? array();
 		$replace = ! empty( $definition['replace'] );
 
-		if ( ! empty( $current ) && ! $replace ) {
-			// Existing field types are extended by default so public extension APIs
-			// can add validators, serializers, or client metadata incrementally.
-			// Pass `replace => true` to fully replace a custom type definition, or
-			// `override_builtin => true` to intentionally replace a built-in type.
-			if ( $this->is_builtin( $type ) && empty( $definition['override_builtin'] ) ) {
-				$definition = wp_parse_args( $definition, $current );
-			} elseif ( empty( $definition['override_builtin'] ) ) {
-				$definition = wp_parse_args( $definition, $current );
-			}
+		if ( ! empty( $current ) && ! $replace && empty( $definition['override_builtin'] ) ) {
+			$definition = wp_parse_args( $definition, $current );
 		}
 
 		$this->types[ $type ] = wp_parse_args(
@@ -87,94 +79,41 @@ final class FieldTypeRegistry {
 		return isset( $this->types[ sanitize_key( $type ) ] );
 	}
 
-	/**
-	 * Return the render callback for a field type.
-	 *
-	 * @return callable|null
-	 */
 	public function render_callback( string $type ): ?callable {
-		$type = sanitize_key( $type );
-
-		if ( ! isset( $this->types[ $type ]['render'] ) || ! is_callable( $this->types[ $type ]['render'] ) ) {
-			return null;
-		}
-
-		return $this->types[ $type ]['render'];
+		return $this->get_callable( $type, 'render' );
 	}
 
-	/**
-	 * Return the nested render callback for a field type.
-	 *
-	 * @return callable|null
-	 */
 	public function nested_render_callback( string $type ): ?callable {
-		$type = sanitize_key( $type );
-
-		if ( ! isset( $this->types[ $type ]['render_nested'] ) || ! is_callable( $this->types[ $type ]['render_nested'] ) ) {
-			return null;
-		}
-
-		return $this->types[ $type ]['render_nested'];
+		return $this->get_callable( $type, 'render_nested' );
 	}
 
-	/**
-	 * Return the sanitize callback for a field type.
-	 *
-	 * @return callable|null
-	 */
 	public function sanitize_callback( string $type ): ?callable {
-		$type = sanitize_key( $type );
-
-		if ( ! isset( $this->types[ $type ]['sanitize'] ) || ! is_callable( $this->types[ $type ]['sanitize'] ) ) {
-			return null;
-		}
-
-		return $this->types[ $type ]['sanitize'];
+		return $this->get_callable( $type, 'sanitize' );
 	}
 
-	/**
-	 * Return the missing-submission callback for a field type.
-	 *
-	 * @return callable|null
-	 */
 	public function missing_submission_callback( string $type ): ?callable {
-		$type = sanitize_key( $type );
-
-		if ( ! isset( $this->types[ $type ]['missing_submission'] ) || ! is_callable( $this->types[ $type ]['missing_submission'] ) ) {
-			return null;
-		}
-
-		return $this->types[ $type ]['missing_submission'];
+		return $this->get_callable( $type, 'missing_submission' );
 	}
 
-	/**
-	 * Return the validate callback for a field type.
-	 *
-	 * @return callable|null
-	 */
 	public function validate_callback( string $type ): ?callable {
-		$type = sanitize_key( $type );
+		return $this->get_callable( $type, 'validate' );
+	}
 
-		if ( ! isset( $this->types[ $type ]['validate'] ) || ! is_callable( $this->types[ $type ]['validate'] ) ) {
-			return null;
-		}
-
-		return $this->types[ $type ]['validate'];
+	public function serialize_callback( string $type ): ?callable {
+		return $this->get_callable( $type, 'serialize' );
 	}
 
 	/**
-	 * Return the serialize callback for a field type.
-	 *
 	 * @return callable|null
 	 */
-	public function serialize_callback( string $type ): ?callable {
+	private function get_callable( string $type, string $key ): ?callable {
 		$type = sanitize_key( $type );
 
-		if ( ! isset( $this->types[ $type ]['serialize'] ) || ! is_callable( $this->types[ $type ]['serialize'] ) ) {
+		if ( ! isset( $this->types[ $type ][ $key ] ) || ! is_callable( $this->types[ $type ][ $key ] ) ) {
 			return null;
 		}
 
-		return $this->types[ $type ]['serialize'];
+		return $this->types[ $type ][ $key ];
 	}
 
 	/**

--- a/packages/AdminConfig/src/Framework/Framework.php
+++ b/packages/AdminConfig/src/Framework/Framework.php
@@ -15,7 +15,6 @@ use Lerm\AdminConfig\Framework\Contracts\FrameworkContract;
 use Lerm\AdminConfig\Framework\Contracts\StorageBackend;
 use Lerm\AdminConfig\Framework\FieldTypes\FieldTypeRegistry;
 use Lerm\AdminConfig\Framework\Contracts\AssetResolver;
-use Lerm\AdminConfig\Framework\Resolvers\DefaultAssetResolver;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
 use Lerm\AdminConfig\Modules\AsyncFieldsModule;
 use Lerm\AdminConfig\Modules\AdvancedFieldsModule;
@@ -52,15 +51,11 @@ final class Framework implements FrameworkContract {
 
 	private AssetResolver $asset_resolver;
 
-	public function __construct( ?AssetResolver $resolver = null ) {
+	public function __construct( AssetResolver $resolver ) {
 		$this->field_types   = new FieldTypeRegistry();
 		$this->field_modules = new FieldModuleRegistry( $this->field_types );
 		$this->register_default_field_modules();
-		$this->asset_resolver = $resolver ?? new DefaultAssetResolver(
-			// When embedded in a theme/package tree, default to the bundled
-			// AdminConfig assets. Plugin bootstrap injects its own resolver.
-			trailingslashit( get_template_directory_uri() . '/packages/AdminConfig/assets' )
-		);
+		$this->asset_resolver = $resolver;
 	}
 
 	/**

--- a/packages/AdminConfig/src/WordPress/EmbeddedBootstrap.php
+++ b/packages/AdminConfig/src/WordPress/EmbeddedBootstrap.php
@@ -20,7 +20,6 @@ final class EmbeddedBootstrap {
 
 	public static function boot( string $assets_url, string $version_constant = 'LERM_VERSION', ?callable $registrar = null ): Runtime {
 		$runtime = new Runtime(
-			null,
 			new Framework(
 				new DefaultAssetResolver( $assets_url, $version_constant )
 			)

--- a/packages/AdminConfig/src/WordPress/PluginBootstrap.php
+++ b/packages/AdminConfig/src/WordPress/PluginBootstrap.php
@@ -19,7 +19,6 @@ final class PluginBootstrap {
 
 	public static function boot( string $plugin_file, ?callable $registrar = null ): Runtime {
 		$runtime = new Runtime(
-			null,
 			new Framework(
 				new PluginAssetResolver( $plugin_file )
 			)

--- a/packages/AdminConfig/src/WordPress/Runtime.php
+++ b/packages/AdminConfig/src/WordPress/Runtime.php
@@ -61,7 +61,7 @@ final class Runtime {
 
 	private bool $boot_requested = false;
 
-	public function __construct( ?SchemaRegistry $registry = null, Framework $framework ) {
+	public function __construct( Framework $framework, ?SchemaRegistry $registry = null ) {
 		$this->framework    = $framework;
 		$this->registry     = $registry ?? new SchemaRegistry( new SchemaCompiler( $this->framework->field_types() ) );
 		$this->stores       = new StoreResolver( $this->framework );

--- a/packages/AdminConfig/src/WordPress/Runtime.php
+++ b/packages/AdminConfig/src/WordPress/Runtime.php
@@ -61,8 +61,8 @@ final class Runtime {
 
 	private bool $boot_requested = false;
 
-	public function __construct( ?SchemaRegistry $registry = null, ?Framework $framework = null ) {
-		$this->framework    = $framework ?? new Framework();
+	public function __construct( ?SchemaRegistry $registry = null, Framework $framework ) {
+		$this->framework    = $framework;
 		$this->registry     = $registry ?? new SchemaRegistry( new SchemaCompiler( $this->framework->field_types() ) );
 		$this->stores       = new StoreResolver( $this->framework );
 		$this->containers   = new ContainerRegistry();

--- a/packages/AdminConfig/tests/Integration/MultisiteSchemaIntegrationTest.php
+++ b/packages/AdminConfig/tests/Integration/MultisiteSchemaIntegrationTest.php
@@ -25,7 +25,7 @@ final class MultisiteSchemaIntegrationTest extends WpIntegrationTestCase {
 	public function testSchemaDemoRegistersAndPersistsNetworkSettings(): void {
 		delete_site_option( 'acme_demo_network_settings' );
 
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 
 		SchemaDemoPlugin::register( $runtime );
 

--- a/packages/AdminConfig/tests/Integration/StoreBackendsIntegrationTest.php
+++ b/packages/AdminConfig/tests/Integration/StoreBackendsIntegrationTest.php
@@ -17,7 +17,7 @@ final class StoreBackendsIntegrationTest extends WpIntegrationTestCase {
 		delete_option( 'lerm_integration_option' );
 		delete_site_option( 'lerm_integration_site_option' );
 
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		$runtime->register( self::make_store_schema( 'integration-option', 'option', 'lerm_integration_option' ) );
 		$runtime->register( self::make_store_schema( 'integration-site-option', 'site_option', 'lerm_integration_site_option' ) );
 
@@ -69,7 +69,7 @@ final class StoreBackendsIntegrationTest extends WpIntegrationTestCase {
 		delete_user_meta( $user_id, 'lerm_integration_user_meta' );
 		delete_comment_meta( $comment_id, 'lerm_integration_comment_meta' );
 
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		$runtime->register( self::make_store_schema( 'integration-post-meta', 'post_meta', 'lerm_integration_post_meta' ) );
 		$runtime->register( self::make_store_schema( 'integration-term-meta', 'term_meta', 'lerm_integration_term_meta' ) );
 		$runtime->register( self::make_store_schema( 'integration-user-meta', 'user_meta', 'lerm_integration_user_meta' ) );

--- a/packages/AdminConfig/tests/Integration/WpIntegrationTestCase.php
+++ b/packages/AdminConfig/tests/Integration/WpIntegrationTestCase.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Lerm\AdminConfig\Tests\Integration;
 
-use PHPUnit\Framework\TestCase;
+use Lerm\AdminConfig\Tests\Support\TestCase;
 
 abstract class WpIntegrationTestCase extends TestCase {
 

--- a/packages/AdminConfig/tests/Smoke/ExamplesSmokeTest.php
+++ b/packages/AdminConfig/tests/Smoke/ExamplesSmokeTest.php
@@ -17,7 +17,7 @@ use Lerm\AdminConfig\WordPress\Runtime;
 final class ExamplesSmokeTest extends TestCase {
 
 	public function testExampleRegistrationsProduceExpectedSchemas(): void {
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 
 		require_once dirname( __DIR__, 2 ) . '/examples/schema-demo-plugin/src/DemoExtensions.php';
 		require_once dirname( __DIR__, 2 ) . '/examples/schema-demo-plugin/src/SchemaDemoPlugin.php';

--- a/packages/AdminConfig/tests/Support/TestCase.php
+++ b/packages/AdminConfig/tests/Support/TestCase.php
@@ -9,10 +9,22 @@ declare( strict_types=1 );
 
 namespace Lerm\AdminConfig\Tests\Support;
 
+use Lerm\AdminConfig\Framework\Framework;
+use Lerm\AdminConfig\Framework\Resolvers\DefaultAssetResolver;
+use Lerm\AdminConfig\WordPress\Runtime;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Throwable;
 
 abstract class TestCase extends BaseTestCase {
+
+	protected function runtime(): Runtime {
+		return new Runtime(
+			null,
+			new Framework(
+				new DefaultAssetResolver( 'https://example.test/admin-config/assets/' )
+			)
+		);
+	}
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/packages/AdminConfig/tests/Support/TestCase.php
+++ b/packages/AdminConfig/tests/Support/TestCase.php
@@ -19,7 +19,6 @@ abstract class TestCase extends BaseTestCase {
 
 	protected function runtime(): Runtime {
 		return new Runtime(
-			null,
 			new Framework(
 				new DefaultAssetResolver( 'https://example.test/admin-config/assets/' )
 			)

--- a/packages/AdminConfig/tests/Unit/BlockEditorPanelTest.php
+++ b/packages/AdminConfig/tests/Unit/BlockEditorPanelTest.php
@@ -141,7 +141,6 @@ final class BlockEditorPanelTest extends TestCase {
 
 	private function runtime_with_metabox_schema(): Runtime {
 		$runtime = new Runtime(
-			null,
 			new Framework(
 				new class() implements AssetResolver {
 					public function url( string $filename ): string {

--- a/packages/AdminConfig/tests/Unit/ExamplesTest.php
+++ b/packages/AdminConfig/tests/Unit/ExamplesTest.php
@@ -20,14 +20,14 @@ final class ExamplesTest extends TestCase {
 		require_once dirname( __DIR__, 2 ) . '/examples/schema-demo-plugin/src/DemoExtensions.php';
 		require_once dirname( __DIR__, 2 ) . '/examples/schema-demo-plugin/src/SchemaDemoPlugin.php';
 
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		SchemaDemoPlugin::register( $runtime );
 
 		self::assertFalse( $runtime->has( 'acme-demo-network-settings' ) );
 
 		$GLOBALS['lerm_admin_config_is_multisite'] = true;
 
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		SchemaDemoPlugin::register( $runtime );
 
 		self::assertTrue( $runtime->has( 'acme-demo-network-settings' ) );
@@ -36,7 +36,7 @@ final class ExamplesTest extends TestCase {
 	public function testEmbeddedThemeDemoRegistersExpectedSchemas(): void {
 		require_once dirname( __DIR__, 2 ) . '/examples/embedded-theme-demo/src/EmbeddedThemeDemo.php';
 
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		EmbeddedThemeDemo::register( $runtime );
 
 		self::assertTrue( $runtime->has( 'acme-theme-style-kit' ) );

--- a/packages/AdminConfig/tests/Unit/RestEndpointsTest.php
+++ b/packages/AdminConfig/tests/Unit/RestEndpointsTest.php
@@ -18,7 +18,7 @@ use Lerm\AdminConfig\WordPress\Runtime;
 final class RestEndpointsTest extends TestCase {
 
 	public function testRegistersCanonicalAndLegacySchemaRestRoutes(): void {
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		unset( $runtime );
 
 		do_action( 'rest_api_init' );
@@ -125,7 +125,7 @@ final class RestEndpointsTest extends TestCase {
 	public function testCanonicalSchemaIndexListsAccessibleSummaries(): void {
 		$runtime = $this->runtime_with_schema();
 
-		$private = new Runtime();
+		$private = $this->runtime();
 		$private->register(
 			array(
 				'id'       => 'private_index_schema',
@@ -162,7 +162,7 @@ final class RestEndpointsTest extends TestCase {
 	}
 
 	public function testSchemaEndpointDoesNotExposeServerCapabilitiesToClient(): void {
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		$runtime->register(
 			array(
 				'id'        => 'private_rest_test',
@@ -275,7 +275,7 @@ final class RestEndpointsTest extends TestCase {
 	}
 
 	public function testRegisteredRestRoutesDispatchToRuntimeOwningRequestedSchema(): void {
-		$empty_runtime = new Runtime();
+		$empty_runtime = $this->runtime();
 		unset( $empty_runtime );
 
 		$runtime = $this->runtime_with_schema();
@@ -315,7 +315,7 @@ final class RestEndpointsTest extends TestCase {
 	}
 
 	public function testRegisteredRestDispatchCoversResetImportExportAndDataSourceAcrossRuntimePool(): void {
-		$empty_runtime = new Runtime();
+		$empty_runtime = $this->runtime();
 		unset( $empty_runtime );
 
 		$runtime = $this->runtime_with_schema();
@@ -802,7 +802,7 @@ final class RestEndpointsTest extends TestCase {
 	}
 
 	public function testMissingSchemaReturnsRestError(): void {
-		$response = ( new SchemaController( new Runtime() ) )->schema( $this->request( array( 'id' => 'missing' ) ) );
+		$response = ( new SchemaController( $this->runtime() ) )->schema( $this->request( array( 'id' => 'missing' ) ) );
 
 		$this->assertInstanceOf( \WP_Error::class, $response );
 		$this->assertSame( 'schema_not_found', $response->get_error_code() );
@@ -810,7 +810,7 @@ final class RestEndpointsTest extends TestCase {
 	}
 
 	private function runtime_with_schema(): Runtime {
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		$runtime->register(
 			array(
 				'id'       => 'rest_test',
@@ -972,7 +972,7 @@ final class RestEndpointsTest extends TestCase {
 	}
 
 	private function runtime_with_meta_schema(): Runtime {
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		$runtime->register(
 			array(
 				'id'        => 'rest_meta',

--- a/packages/AdminConfig/tests/Unit/RuntimeTest.php
+++ b/packages/AdminConfig/tests/Unit/RuntimeTest.php
@@ -16,7 +16,7 @@ use Lerm\AdminConfig\WordPress\Runtime;
 final class RuntimeTest extends TestCase {
 
 	public function testRuntimeRegistersRestAndAdminPostWithoutAjaxHandlers(): void {
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		$runtime->register(
 			array(
 				'id'       => 'rest_only_runtime',
@@ -44,7 +44,7 @@ final class RuntimeTest extends TestCase {
 	}
 
 	public function testAllFallsBackToDefaultsWhenMetaContextIsMissing(): void {
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		$runtime->register(
 			array(
 				'id'        => 'entry_meta',
@@ -85,7 +85,7 @@ final class RuntimeTest extends TestCase {
 	}
 
 	public function testStoreStillThrowsWhenMetaContextIsMissing(): void {
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		$runtime->register(
 			array(
 				'id'        => 'entry_meta',
@@ -119,7 +119,7 @@ final class RuntimeTest extends TestCase {
 	}
 
 	public function testBootReportsMissingContainerAdaptersInDebugMode(): void {
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		$runtime->register(
 			array(
 				'id'        => 'missing_container_schema',
@@ -154,7 +154,7 @@ final class RuntimeTest extends TestCase {
 	}
 
 	public function testBootReportsInvalidStoreConfigurationWithoutThrowing(): void {
-		$runtime = new Runtime();
+		$runtime = $this->runtime();
 		$runtime->register(
 			array(
 				'id'        => 'invalid_store_schema',


### PR DESCRIPTION
Remove hardcoded theme-path dependency from Framework constructor. Framework now requires AssetResolver (removes get_template_directory_uri fallback). Runtime now requires Framework. FieldTypeRegistry: six callback accessors extracted into single get_callable() helper. Tests: runtime() factory added to base TestCase.