### PR TITLE
fix: Runtime constructor param order + @package tag cleanup

### DIFF
--- a/packages/AdminConfig/src/Framework/Admin/ContainerFieldRenderer.php
+++ b/packages/AdminConfig/src/Framework/Admin/ContainerFieldRenderer.php
@@ -2,7 +2,7 @@
 /**
  * Classic admin structured container field renderer.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
+++ b/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
@@ -2,7 +2,7 @@
 /**
  * Generic native options page container.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Backends/ArrayBackend.php
+++ b/packages/AdminConfig/src/Framework/Backends/ArrayBackend.php
@@ -5,7 +5,7 @@
  * Useful for rendering schema defaults in add/new forms before a persistent
  * object ID exists, such as taxonomy term creation screens.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Backends/CommentMetaBackend.php
+++ b/packages/AdminConfig/src/Framework/Backends/CommentMetaBackend.php
@@ -2,7 +2,7 @@
 /**
  * Storage backend backed by WordPress comment meta.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Backends/OptionBackend.php
+++ b/packages/AdminConfig/src/Framework/Backends/OptionBackend.php
@@ -5,7 +5,7 @@
  * This is the default backend used by the admin config runtime for theme/plugin
  * settings pages.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Backends/PostMetaBackend.php
+++ b/packages/AdminConfig/src/Framework/Backends/PostMetaBackend.php
@@ -8,7 +8,7 @@
  *   $backend = new PostMetaBackend( $post_id, 'my_cpt_settings' );
  *   $store   = new OptionStore( $definition, $field_types, $backend );
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Backends/SiteOptionBackend.php
+++ b/packages/AdminConfig/src/Framework/Backends/SiteOptionBackend.php
@@ -2,7 +2,7 @@
 /**
  * Storage backend backed by WordPress site options.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Backends/TermMetaBackend.php
+++ b/packages/AdminConfig/src/Framework/Backends/TermMetaBackend.php
@@ -10,7 +10,7 @@
  * matching the behaviour of the OptionBackend so that OptionStore can work
  * transparently with either backend.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Backends/UserMetaBackend.php
+++ b/packages/AdminConfig/src/Framework/Backends/UserMetaBackend.php
@@ -6,7 +6,7 @@
  *   $backend = new UserMetaBackend( $user_id, 'my_user_settings' );
  *   $store   = new OptionStore( $definition, $field_types, $backend );
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Contracts/StorageBackend.php
+++ b/packages/AdminConfig/src/Framework/Contracts/StorageBackend.php
@@ -16,7 +16,7 @@
  *   'storage' => [ 'type' => 'user_meta',  'object_id' => $user_id ]
  *   'storage' => [ 'type' => 'post_meta',  'object_id' => $post_id ]
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/FieldTypes/AdvancedFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/AdvancedFieldTypes.php
@@ -2,7 +2,7 @@
 /**
  * Advanced field definitions.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/FieldTypes/BuiltinFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/BuiltinFieldTypes.php
@@ -2,7 +2,7 @@
 /**
  * Built-in field type definitions for the admin-config framework.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/FieldTypes/DesignFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/DesignFieldTypes.php
@@ -2,7 +2,7 @@
 /**
  * Native design-oriented composite field controls.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/FieldTypes/ExtendedPrimitiveFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/ExtendedPrimitiveFieldTypes.php
@@ -2,7 +2,7 @@
 /**
  * Extended native fields for controls and presentation.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/FieldTypes/FieldTypeRegistry.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/FieldTypeRegistry.php
@@ -2,7 +2,7 @@
 /**
  * Registry for built-in and custom field types.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
@@ -2,7 +2,7 @@
 /**
  * Structured admin field definitions.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/FieldTypes/ToolFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/ToolFieldTypes.php
@@ -2,7 +2,7 @@
 /**
  * Tool and utility field definitions.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Framework.php
+++ b/packages/AdminConfig/src/Framework/Framework.php
@@ -2,7 +2,7 @@
 /**
  * Core entry point for the admin config runtime.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Storage/OptionStore.php
+++ b/packages/AdminConfig/src/Framework/Storage/OptionStore.php
@@ -9,7 +9,7 @@
  * Backward-compatible: when no backend is supplied the store falls back to the
  * OptionBackend (get_option / update_option), preserving existing behaviour.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );

--- a/packages/AdminConfig/src/Framework/Support/PageSchema.php
+++ b/packages/AdminConfig/src/Framework/Support/PageSchema.php
@@ -2,7 +2,7 @@
 /**
  * Helpers for working with options page schema definitions.
  *
- * @package Lerm
+ * @package Lerm\AdminConfig
  */
 
 declare( strict_types=1 );


### PR DESCRIPTION
Fix PHP 8.1+ deprecated required-param-after-optional in Runtime constructor. Update 20 @package Lerm tags to @package Lerm\AdminConfig.