### PR TITLE
fix: require manage_options capability for schema list endpoint

### DIFF
--- a/packages/AdminConfig/src/Rest/RestEndpoints.php
+++ b/packages/AdminConfig/src/Rest/RestEndpoints.php
@@ -230,7 +230,7 @@ final class RestEndpoints {
 	public static function can_list_schemas( \WP_REST_Request $request ): bool {
 		unset( $request );
 
-		return true;
+		return current_user_can( 'manage_options' );
 	}
 
 	/**


### PR DESCRIPTION
The /schemas list endpoint returned true unconditionally, allowing unauthenticated visitors to enumerate all registered schema IDs, field names, and section structures. Require manage_options capability instead, consistent with the per-schema can_access_schema check.