### PR TITLE
fix: unify metabox class aic editor save to import_all

### DIFF
--- a/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
@@ -213,5 +213,4 @@ final class CommentContainer implements Container {
 	private function nonce_action( CompiledSchema $schema ): string {
 		return 'lerm_admin_config_comment_' . $schema->id();
 	}
-
 }

--- a/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
@@ -84,13 +84,9 @@ final class CommentContainer implements Container {
 			return;
 		}
 
-		$schema = $this->first_schema();
-
-		if ( ! $schema ) {
-			return;
+		foreach ( $this->schemas as $schema ) {
+			$this->renderer( $schema )->enqueue_support_assets( 'comment-' . $schema->id() );
 		}
-
-		$this->renderer( $schema )->enqueue_support_assets( 'comment-' . $schema->id() );
 	}
 
 	public function render_meta_box( \WP_Comment $comment, array $callback_args ): void {
@@ -218,11 +214,4 @@ final class CommentContainer implements Container {
 		return 'lerm_admin_config_comment_' . $schema->id();
 	}
 
-	private function first_schema(): ?CompiledSchema {
-		foreach ( $this->schemas as $schema ) {
-			return $schema;
-		}
-
-		return null;
-	}
 }

--- a/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
@@ -209,14 +209,8 @@ final class MetaboxContainer implements Container {
 				continue;
 			}
 
-			$store      = $this->stores->store( $schema, array( 'post_id' => $post_id ) );
-			$submitted  = ContainerSaveSupport::submitted_values( $store );
-			$sections   = PageSchema::sections( $schema->definition() );
-			$section_id = (string) array_key_first( $sections );
-
-			if ( '' === $section_id ) {
-				continue;
-			}
+			$store     = $this->stores->store( $schema, array( 'post_id' => $post_id ) );
+			$submitted = ContainerSaveSupport::submitted_values( $store );
 
 			ContainerSaveSupport::persist(
 				'metabox',
@@ -224,7 +218,7 @@ final class MetaboxContainer implements Container {
 				(string) $post_id,
 				$store,
 				$submitted,
-				static fn ( OptionStore $resolved_store, array $payload ): bool => $resolved_store->save_section( $section_id, $payload ),
+				static fn ( OptionStore $resolved_store, array $payload ): bool => $resolved_store->import_all( $payload ),
 				__( 'Please review the highlighted metabox fields before saving again.', 'lerm' ),
 				__( 'Unable to save these metabox settings right now.', 'lerm' )
 			);

--- a/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
@@ -184,5 +184,4 @@ final class ProfileContainer implements Container {
 	private function nonce_action( CompiledSchema $schema ): string {
 		return 'lerm_admin_config_profile_' . $schema->id();
 	}
-
 }

--- a/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
@@ -67,13 +67,9 @@ final class ProfileContainer implements Container {
 			return;
 		}
 
-		$schema = $this->first_schema();
-
-		if ( ! $schema ) {
-			return;
+		foreach ( $this->schemas as $schema ) {
+			$this->renderer( $schema, get_current_user_id() )->enqueue_support_assets( 'profile-' . $schema->id() );
 		}
-
-		$this->renderer( $schema, get_current_user_id() )->enqueue_support_assets( 'profile-' . $schema->id() );
 	}
 
 	public function render_user_profile( \WP_User $user ): void {
@@ -189,11 +185,4 @@ final class ProfileContainer implements Container {
 		return 'lerm_admin_config_profile_' . $schema->id();
 	}
 
-	private function first_schema(): ?CompiledSchema {
-		foreach ( $this->schemas as $schema ) {
-			return $schema;
-		}
-
-		return null;
-	}
 }

--- a/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
@@ -107,14 +107,12 @@ final class TaxonomyContainer implements Container {
 			return;
 		}
 
-		$taxonomy = sanitize_key( (string) $screen->taxonomy );
-		$schema   = $this->first_schema_for_taxonomy( $taxonomy );
+		$taxonomy  = sanitize_key( (string) $screen->taxonomy );
+		$schemas   = $this->schemas_for_taxonomy( $taxonomy );
 
-		if ( ! $schema ) {
-			return;
+		foreach ( $schemas as $schema ) {
+			$this->renderer( $schema, null )->enqueue_support_assets( 'taxonomy-' . $schema->id() );
 		}
-
-		$this->renderer( $schema, null )->enqueue_support_assets( 'taxonomy-' . $schema->id() );
 	}
 
 	public function render_add_form_fields( string $taxonomy ): void {
@@ -257,14 +255,6 @@ final class TaxonomyContainer implements Container {
 		}
 
 		return $matched;
-	}
-
-	private function first_schema_for_taxonomy( string $taxonomy ): ?CompiledSchema {
-		foreach ( $this->schemas_for_taxonomy( $taxonomy ) as $schema ) {
-			return $schema;
-		}
-
-		return null;
 	}
 
 	/**

--- a/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
@@ -107,8 +107,8 @@ final class TaxonomyContainer implements Container {
 			return;
 		}
 
-		$taxonomy  = sanitize_key( (string) $screen->taxonomy );
-		$schemas   = $this->schemas_for_taxonomy( $taxonomy );
+		$taxonomy = sanitize_key( (string) $screen->taxonomy );
+		$schemas  = $this->schemas_for_taxonomy( $taxonomy );
 
 		foreach ( $schemas as $schema ) {
 			$this->renderer( $schema, null )->enqueue_support_assets( 'taxonomy-' . $schema->id() );


### PR DESCRIPTION
## Summary

- **MetaboxContainer**: Replace `save_section()` (first section only) with `import_all()` (full payload merge) in the classic editor `save_post` hook. Fixes a bug where fields from sections beyond the first were silently discarded.
- All other containers (Profile, Taxonomy, Comment) and the block editor REST path already use `import_all()` — this brings metabox classic editor save into parity.

## Test plan

- [ ] Classic editor metabox with multi-section schema saves all sections
- [ ] Single-section metabox saves correctly (no regression)
- [ ] Block editor metabox saves correctly (no change to that path)