### PR TITLE
fix: AdminConfig block-panel UX improvements and asset enqueuing fixes

### DIFF
--- a/packages/AdminConfig/assets/block-panel.css
+++ b/packages/AdminConfig/assets/block-panel.css
@@ -1,0 +1,377 @@
+/**
+ * AdminConfig block editor panel styles.
+ * Matches native WordPress editor panel visual conventions.
+ */
+
+/* ---- Status / Message / Meta ---- */
+
+.lerm-admin-config-block-panel__status {
+	display: none;
+}
+
+.lerm-admin-config-block-panel__message {
+	margin: 0 0 12px;
+	padding: 8px 12px;
+	font-size: 12px;
+	line-height: 1.4;
+	background: #f0f0f1;
+	border-left: 4px solid #007cba;
+	border-radius: 2px;
+}
+
+.lerm-admin-config-block-panel__message[data-error-count]:not([data-error-count="0"]),
+.lerm-admin-config-block-panel__message[role="alert"] {
+	background: #fcf0f1;
+	border-left-color: #cc1818;
+}
+
+.lerm-admin-config-block-panel__meta {
+	margin: 0 0 16px;
+	font-size: 11px;
+	color: #757575;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+
+/* ---- Save Notice ---- */
+
+.lerm-admin-config-block-panel__save-notice {
+	margin: 0 0 12px;
+	padding: 8px 12px;
+	font-size: 12px;
+	line-height: 1.4;
+	background: #fcf9e8;
+	border-left: 4px solid #dba617;
+	border-radius: 2px;
+	color: #755100;
+}
+
+/* ---- Sections ---- */
+
+.lerm-admin-config-block-panel__section {
+	margin: 0 0 24px;
+	padding: 0;
+	border: 0;
+}
+
+.lerm-admin-config-block-panel__section + .lerm-admin-config-block-panel__section {
+	padding-top: 20px;
+	border-top: 1px solid #e0e0e0;
+}
+
+.lerm-admin-config-block-panel__section h3 {
+	margin: 0 0 12px;
+	font-size: 13px;
+	font-weight: 600;
+	color: #1e1e1e;
+}
+
+.lerm-admin-config-block-panel__section-description {
+	margin: 0 0 16px;
+	font-size: 12px;
+	color: #757575;
+	line-height: 1.4;
+}
+
+/* ---- Fields ---- */
+
+.lerm-admin-config-block-panel__field {
+	margin: 0 0 20px;
+}
+
+.lerm-admin-config-block-panel__field:last-child {
+	margin-bottom: 0;
+}
+
+.lerm-admin-config-block-panel__field.is-error {
+	padding: 0 0 0 8px;
+	border-left: 3px solid #cc1818;
+}
+
+/* Field description text (rendered inside controls) is handled by controls */
+
+.lerm-admin-config-block-panel__field-description {
+	margin: 4px 0 0;
+	font-size: 12px;
+	color: #757575;
+	line-height: 1.4;
+}
+
+/* Field errors */
+
+.lerm-admin-config-block-panel__field-error {
+	margin: 6px 0 0;
+	font-size: 12px;
+	color: #cc1818;
+	line-height: 1.4;
+}
+
+/* ---- Read-only / Unsupported Fields ---- */
+
+.lerm-admin-config-block-panel__readonly-field,
+.lerm-admin-config-block-panel__unsupported-field {
+	margin-bottom: 16px;
+	padding: 12px;
+	background: #f9f9f9;
+	border: 1px solid #e0e0e0;
+	border-radius: 2px;
+}
+
+.lerm-admin-config-block-panel__unsupported-field {
+	opacity: 0.65;
+}
+
+.lerm-admin-config-block-panel__unsupported-message {
+	margin: 6px 0 0;
+	font-size: 11px;
+	color: #757575;
+	font-style: italic;
+}
+
+/* ---- Actions Bar ---- */
+
+.lerm-admin-config-block-panel__actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 16px;
+	padding-top: 16px;
+	border-top: 1px solid #e0e0e0;
+}
+
+.lerm-admin-config-block-panel__dirty-state {
+	margin-left: auto;
+	font-size: 11px;
+	padding: 2px 8px;
+	border-radius: 10px;
+	line-height: 18px;
+}
+
+.lerm-admin-config-block-panel__dirty-state[data-dirty="true"] {
+	color: #755100;
+	background: #fcf9e8;
+}
+
+.lerm-admin-config-block-panel__dirty-state[data-dirty="false"] {
+	color: #50575e;
+	background: #f0f0f1;
+}
+
+/* ---- Nested / Composite Fields ---- */
+
+.lerm-admin-config-block-panel__nested-field {
+	margin-bottom: 16px;
+	padding: 12px;
+	background: #f9f9f9;
+	border: 1px solid #e0e0e0;
+	border-radius: 2px;
+}
+
+.lerm-admin-config-block-panel__nested-field--unavailable {
+	opacity: 0.55;
+	pointer-events: none;
+}
+
+.lerm-admin-config-block-panel__composite-field {
+	margin-bottom: 16px;
+}
+
+.lerm-admin-config-block-panel__composite-item {
+	padding: 8px 0;
+	border-bottom: 1px solid #f0f0f1;
+}
+
+.lerm-admin-config-block-panel__composite-item:last-child {
+	border-bottom: 0;
+}
+
+.lerm-admin-config-block-panel__group {
+	margin-bottom: 20px;
+}
+
+.lerm-admin-config-block-panel__group-item {
+	margin-bottom: 12px;
+	padding: 12px;
+	border: 1px solid #e0e0e0;
+	border-radius: 2px;
+}
+
+/* ---- Fieldset / Typography / Background ---- */
+
+.lerm-admin-config-block-panel__fieldset {
+	margin-bottom: 20px;
+	padding: 12px;
+	background: #f9f9f9;
+	border: 1px solid #e0e0e0;
+	border-radius: 2px;
+}
+
+.lerm-admin-config-block-panel__typography,
+.lerm-admin-config-block-panel__background {
+	margin-bottom: 20px;
+}
+
+/* ---- Media Controls ---- */
+
+.lerm-admin-config-block-panel__media-preview {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	margin-top: 8px;
+}
+
+.lerm-admin-config-block-panel__media-preview-item {
+	width: 80px;
+	height: 80px;
+	object-fit: cover;
+	border: 1px solid #ddd;
+	border-radius: 2px;
+	background: #f0f0f1;
+}
+
+.lerm-admin-config-block-panel__media-empty {
+	margin-top: 8px;
+	font-size: 12px;
+	color: #757575;
+	font-style: italic;
+}
+
+.lerm-admin-config-block-panel__media-control {
+	margin-bottom: 16px;
+}
+
+.lerm-admin-config-block-panel__media-actions {
+	display: flex;
+	gap: 8px;
+	margin-top: 8px;
+}
+
+.lerm-admin-config-block-panel__media-url {
+	margin-top: 8px;
+}
+
+.lerm-admin-config-block-panel__media-url-preview {
+	margin-top: 6px;
+	font-size: 12px;
+	color: #757575;
+	word-break: break-all;
+}
+
+/* ---- Range ---- */
+
+.lerm-admin-config-block-panel__range {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.lerm-admin-config-block-panel__range input[type="range"] {
+	flex: 1;
+}
+
+/* ---- Date ---- */
+
+.lerm-admin-config-block-panel__date {
+	max-width: 280px;
+}
+
+.lerm-admin-config-block-panel__date-range {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 12px;
+}
+
+/* ---- Radio / Checkbox List ---- */
+
+.lerm-admin-config-block-panel__radio {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.lerm-admin-config-block-panel__checkbox-list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+/* ---- Button Set ---- */
+
+.lerm-admin-config-block-panel__button-set {
+	display: inline-flex;
+	gap: 0;
+	border: 1px solid #757575;
+	border-radius: 2px;
+	overflow: hidden;
+}
+
+.lerm-admin-config-block-panel__button-set .components-button {
+	border-radius: 0 !important;
+	border-right: 1px solid #757575;
+}
+
+.lerm-admin-config-block-panel__button-set .components-button:last-child {
+	border-right: 0;
+}
+
+/* ---- Color ---- */
+
+.lerm-admin-config-block-panel__color {
+	margin-bottom: 16px;
+}
+
+.lerm-admin-config-block-panel__palette-swatches {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-top: 8px;
+}
+
+/* ---- AJAX Select ---- */
+
+.lerm-admin-config-block-panel__ajax-select {
+	margin-bottom: 16px;
+}
+
+.lerm-admin-config-block-panel__ajax-select-selected {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	margin-bottom: 8px;
+}
+
+.lerm-admin-config-block-panel__ajax-select-search {
+	margin-bottom: 8px;
+}
+
+.lerm-admin-config-block-panel__ajax-select-status {
+	margin-bottom: 4px;
+	font-size: 11px;
+	color: #757575;
+}
+
+.lerm-admin-config-block-panel__ajax-select-results {
+	max-height: 200px;
+	overflow-y: auto;
+	border: 1px solid #ddd;
+	border-radius: 2px;
+	background: #fff;
+}
+
+/* ---- Visual Choice ---- */
+
+.lerm-admin-config-block-panel__visual-choice {
+	margin-bottom: 16px;
+}
+
+.lerm-admin-config-block-panel__visual-choice-options {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+/* ---- Spinner ---- */
+
+.lerm-admin-config-block-panel .components-spinner {
+	margin: 12px auto;
+}

--- a/packages/AdminConfig/resources/block-panel/index.js
+++ b/packages/AdminConfig/resources/block-panel/index.js
@@ -442,7 +442,7 @@ const renderUnavailableField = (createElement, field, controlType, status, error
  * @param {{ createElement: Function, useEffect: Function, useMemo: Function, useState: Function }} element
  */
 const createPanelComponent = (config, Panel, element) => {
-	const { createElement, useEffect, useMemo, useState } = element;
+	const { createElement, useEffect, useMemo, useRef, useState } = element;
 
 	return function AdminConfigBlockPanel() {
 		const runtime = useMemo(() => createBlockPanelRuntime(config), []);
@@ -521,10 +521,40 @@ const createPanelComponent = (config, Panel, element) => {
 		const fieldsById = asRecord(state.schema.fields);
 		const dependencies = asRecord(state.schema.dependencies);
 		const dirty = isSchemaStateDirty(state);
+		const dirtyRef = useRef(false);
+		dirtyRef.current = dirty;
+
+		useEffect(() => {
+			const handleBeforeUnload = (event) => {
+				if (dirtyRef.current) {
+					event.preventDefault();
+					event.returnValue = '';
+				}
+			};
+			window.addEventListener('beforeunload', handleBeforeUnload);
+			return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+		}, []);
+
+		useEffect(() => {
+			const wpData = window.wp && window.wp.data;
+			const editorDispatch = wpData && wpData.dispatch && wpData.dispatch('core/editor');
+			if (dirty && editorDispatch && typeof editorDispatch.lockPostSaving === 'function') {
+				editorDispatch.lockPostSaving('lerm-admin-config-unsaved');
+			} else if (!dirty && editorDispatch && typeof editorDispatch.unlockPostSaving === 'function') {
+				editorDispatch.unlockPostSaving('lerm-admin-config-unsaved');
+			}
+			return () => {
+				if (editorDispatch && typeof editorDispatch.unlockPostSaving === 'function') {
+					editorDispatch.unlockPostSaving('lerm-admin-config-unsaved');
+				}
+			};
+		}, [dirty]);
 		const isBusy = status === 'loading' || status === 'saving';
 		const canRenderFields = status === 'ready' || (status === 'error' && Object.keys(state.schema || {}).length > 0);
 		const Button = components.Button;
 		const Spinner = components.Spinner;
+		const Modal = components.Modal;
+		const [showDiscardDialog, setShowDiscardDialog] = useState(false);
 		const fieldBody = [];
 		const syncPanelState = () => setState(runtime.getState());
 		const saveChanges = () => {
@@ -534,6 +564,11 @@ const createPanelComponent = (config, Panel, element) => {
 			savePromise.then(syncPanelState, syncPanelState);
 		};
 		const discardChanges = () => {
+			if (typeof Modal === 'function') {
+				setShowDiscardDialog(true);
+				return;
+			}
+
 			const shouldDiscard = typeof window === 'undefined' ||
 				typeof window.confirm !== 'function' ||
 				window.confirm('Discard unsaved AdminConfig changes?');
@@ -542,6 +577,12 @@ const createPanelComponent = (config, Panel, element) => {
 				return;
 			}
 
+			runtime.discardChanges();
+			syncPanelState();
+		};
+
+		const handleConfirmDiscard = () => {
+			setShowDiscardDialog(false);
 			runtime.discardChanges();
 			syncPanelState();
 		};
@@ -650,6 +691,16 @@ const createPanelComponent = (config, Panel, element) => {
 		}
 
 		if (fieldBody.length && hasEditableFields) {
+			if (dirty) {
+				body.push(createElement(
+					'div',
+					{
+						className: 'lerm-admin-config-block-panel__save-notice',
+						key: 'save-notice',
+					},
+					'Save AdminConfig changes before updating the post — they are stored separately.'
+				))
+			}
 			body.push(createElement(
 				'div',
 				{
@@ -713,7 +764,7 @@ const createPanelComponent = (config, Panel, element) => {
 			));
 		}
 
-		return createElement(
+		const panelElement = createElement(
 			Panel,
 			{
 				className: 'lerm-admin-config-block-panel',
@@ -734,6 +785,60 @@ const createPanelComponent = (config, Panel, element) => {
 				body
 			)
 		);
+
+		if (showDiscardDialog && typeof Modal === 'function') {
+			return [
+				panelElement,
+				createElement(
+					Modal,
+					{
+						key: 'discard-dialog',
+						title: 'Discard changes?',
+						onRequestClose: () => setShowDiscardDialog(false),
+					},
+					createElement(
+						'div',
+						{ style: { padding: '0 0 16px' } },
+						createElement('p', null, 'Discard unsaved AdminConfig changes?')
+					),
+					createElement(
+						'div',
+						{
+							style: {
+								display: 'flex',
+								gap: '8px',
+								justifyContent: 'flex-end',
+							},
+						},
+						typeof Button === 'function'
+							? createElement(
+								Button,
+								{
+									key: 'cancel',
+									onClick: () => setShowDiscardDialog(false),
+									variant: 'secondary',
+								},
+								'Cancel'
+							)
+							: null,
+						typeof Button === 'function'
+							? createElement(
+								Button,
+								{
+									isDestructive: true,
+									key: 'confirm',
+									onClick: handleConfirmDiscard,
+									variant: 'primary',
+								},
+								'Discard'
+							)
+							: null
+					)
+				),
+			];
+		}
+
+		return panelElement;
 	};
 };
 

--- a/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
@@ -84,6 +84,13 @@ final class MetaboxContainer implements Container {
 			true
 		);
 
+		wp_enqueue_style(
+			$handle,
+			$this->asset_url( 'block-panel.css' ),
+			array( 'wp-components' ),
+			$this->asset_version()
+		);
+
 		$payload = wp_json_encode(
 			array(
 				'restUrl'   => rest_url( 'lerm-admin-config/v1/' ),


### PR DESCRIPTION
## Summary
- Replace native `window.confirm()` with `wp.components.Modal` for discard dialog in block editor
- Add `block-panel.css` stylesheet matching native WordPress panel conventions
- Enqueue assets for all schemas (profile/comment/taxonomy), not just the first one
- Remove deprecated `/schema/` REST routes

## Changes
| File | Change |
|------|--------|
| `resources/block-panel/index.js` | Modal-based discard confirmation with `beforeunload` + `lockPostSaving` guards |
| `assets/block-panel.css` | New stylesheet for block editor panel |
| `src/WordPress/Containers/*.php` | Loop all schemas for asset enqueuing, use `import_all` for MetaboxContainer |
| `src/Rest/RestEndpoints.php` | Remove deprecated `/schema/` routes |

## Test plan
- [ ] Open block editor, edit a post with AdminConfig fields, click Discard → confirm Modal appears
- [ ] Verify Cancel closes the modal without discarding
- [ ] Verify Discard button in modal resets all fields to saved values
- [ ] Verify `beforeunload` and `lockPostSaving` trigger when changes are unsaved
- [ ] Verify assets are enqueued for all profile/comment/taxonomy schemas