### PR TITLE
feat: add wp.data store and i18n bridge (AdminConfig Phase 2)

### DIFF
--- a/packages/AdminConfig/package-lock.json
+++ b/packages/AdminConfig/package-lock.json
@@ -8,7 +8,9 @@
       "devDependencies": {
         "@playwright/test": "^1.52.0",
         "@wordpress/api-fetch": "^7.44.0",
+        "@wordpress/data": "^10.0.0",
         "@wordpress/env": "^10.19.0",
+        "@wordpress/i18n": "^5.0.0",
         "@wordpress/scripts": "^32.0.0",
         "cross-env": "^7.0.3"
       }
@@ -2065,6 +2067,19 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
+      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -7699,6 +7714,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mousetrap": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.15.tgz",
+      "integrity": "sha512-qL0hyIMNPow317QWW/63RvL1x5MVMV+Ru3NaY9f/CuEpCqrmb7WeuK2071ZY5hczOnm38qExWM2i2WtkXLSqFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
@@ -8848,6 +8870,27 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/api-fetch/node_modules/@wordpress/i18n": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.0.tgz",
+      "integrity": "sha512-IXGGUJqN6b7QddU0dZB3HLJKu6uDQuhLsrrzYpUYTjDhfa43XEaikA9xHNgZhqzRtOVYqsNHVliWcISvJ/xjZQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@tannin/sprintf": "^1.3.2",
+        "@wordpress/hooks": "^4.48.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/babel-preset-default": {
       "version": "8.45.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.45.0.tgz",
@@ -9098,6 +9141,106 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/compose": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
+      "integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/undo-manager": "^1.48.0",
+        "change-case": "^4.1.2",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/compose/node_modules/@wordpress/element": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/data": {
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
+      "integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/is-shallow-equal": "^5.48.0",
+        "@wordpress/priority-queue": "^3.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "@wordpress/redux-routine": "^5.48.0",
+        "deepmerge": "^4.3.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "redux": "^5.0.1",
+        "rememo": "^4.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/data/node_modules/@wordpress/element": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
       "version": "6.45.0",
       "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.45.0.tgz",
@@ -9121,6 +9264,34 @@
       "integrity": "sha512-dnSoUiLAoVaMXxFsVi4CrPVYMKOuDBXTghXSmMINX44RZ8WM9cXlY7UqrQnlAcODCVO7FV3+8t/5nDKAjimLfg==",
       "dev": true,
       "license": "BSD"
+    },
+    "node_modules/@wordpress/deprecated": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.48.0.tgz",
+      "integrity": "sha512-aTa7oww6hvTjfIvxLsxlcwYj7skAGPnr1V2S0iBVQfiIn5wJPiGjM9hz4QEf6kyR44Vh0IYjW9wSxVuDMGZUdw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/hooks": "^4.48.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dom": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.48.0.tgz",
+      "integrity": "sha512-9UARZ0YQfmhx9VAi+QynSwu5fOJoG4mmPNTpYW8jDmtKh+9c2YIi1YSQFuOa1sipj78ZLPaBxaceZ7dbxKc3UA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/deprecated": "^4.48.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
     },
     "node_modules/@wordpress/e2e-test-utils-playwright": {
       "version": "1.45.0",
@@ -9208,9 +9379,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.45.0.tgz",
-      "integrity": "sha512-IW4mnA+65XKhABuBkwrQNAlbq97luC6ZIBfdSq0Tkq+AFPqE1lJTMlLo7iBkTpsHsBLyznViPXultq40fz8L7w==",
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.48.0.tgz",
+      "integrity": "sha512-phw399RofSqTqIM4DikmkDfgJ7exDYgPfDuxjv3D2YnUTTUsR+U9fA+pA+/rNUiZD1YOmVILQmkJt6oLaVM+nQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -9293,9 +9464,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.44.0.tgz",
-      "integrity": "sha512-6p2vFvoFaovqnKFnIoy6Kib2XJhTwaJ1VhMXp4tM2PhSLnFMXVm1TpcHeX/kH7E6sWKJACBrDR6FH2nGYMk5dA==",
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.0.tgz",
+      "integrity": "sha512-rU1yGEy0Mb+2oRG5QX/bKIIwKQmYAvATfUQeXIF20/mbR0qutYeVTCIvWEyb4pf71tvnQFiN18RWRXWsvKrDbQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -9304,21 +9475,40 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.17.0.tgz",
-      "integrity": "sha512-v1SLBweg7CRzQ+5+WSC1U93i8h9d3AoB0YBvMsd6gWI5vO8Zh4YKlEMexvrHQC++WN83egwqux84fWEdeU0MUA==",
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
+      "integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.44.0",
+        "@babel/runtime": "7.25.7",
+        "@wordpress/hooks": "^4.26.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
+        "sprintf-js": "^1.1.1",
         "tannin": "^1.2.0"
       },
       "bin": {
         "pot-to-php": "tools/pot-to-php.js"
       },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/i18n/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@wordpress/is-shallow-equal": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.48.0.tgz",
+      "integrity": "sha512-7ipiZ1+m84RfuVhiMbtKm6RN571W3ERV/pTL+fSG2qOVhLqccFmliuFHTKQG+0KIhV8DegOlE6eoKOenf+I9ng==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -9359,6 +9549,41 @@
       "peerDependencies": {
         "@babel/core": ">=7",
         "jest": ">=29"
+      }
+    },
+    "node_modules/@wordpress/keycodes": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.48.0.tgz",
+      "integrity": "sha512-u3Uxxe3rDAqEmerAiJ2X94s7iO3ZVgS+10MFyD4nWhfuB/C6m/M2TqHPgZiKvyDH04EIhe+pIF2KFO4pq7NWsw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/i18n": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.0.tgz",
+      "integrity": "sha512-IXGGUJqN6b7QddU0dZB3HLJKu6uDQuhLsrrzYpUYTjDhfa43XEaikA9xHNgZhqzRtOVYqsNHVliWcISvJ/xjZQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@tannin/sprintf": "^1.3.2",
+        "@wordpress/hooks": "^4.48.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
@@ -9408,15 +9633,48 @@
         "prettier": ">=3"
       }
     },
+    "node_modules/@wordpress/priority-queue": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.48.0.tgz",
+      "integrity": "sha512-NuGrfSSnBC794erb3xSEKrzWLGCNLa+ukob0pyVRtnebU7fPgrhx4NCBCXYK1vTcAta3NAkOVRfUZgcmLFYA6g==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "requestidlecallback": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.45.0.tgz",
-      "integrity": "sha512-UjhIDpoyKKUghPM0tkqd5Whsuk4kqfAfhb5VYGoEYtunDs0rB8IxgFO7hE0PhimHL74QVgaJOlprRZVRCCoQ6w==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.48.0.tgz",
+      "integrity": "sha512-HHOSXLCAlBggfMozwWtX36wgsSt22g2tZwpka47Rjzr3hNY1BZ6SrrFJumiNxooy5PDKbRgcF092PAF82hdJXg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/redux-routine": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
+      "integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "rungen": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "redux": ">=4"
       }
     },
     "node_modules/@wordpress/scripts": {
@@ -9835,6 +10093,20 @@
         "stylelint": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@wordpress/undo-manager": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.48.0.tgz",
+      "integrity": "sha512-HqPGxMvZeWZJ6AVaCqZhfGpH6tqq5+hMlaqh4aCO0SvZ2Gvc6fbXEoVpqWfKozO1DyJW2GnRf8At8PpPt2IopQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/is-shallow-equal": "^5.48.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/url": {
@@ -13507,6 +13779,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/equivalent-key-map": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
+      "integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -17141,6 +17420,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -20644,6 +20930,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mousetrap": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
+      "integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
+      "dev": true,
+      "license": "Apache-2.0 WITH LLVM-exception"
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -23456,6 +23749,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -23505,6 +23805,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -23565,10 +23872,24 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/rememo": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
+      "integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/remove-accents": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
       "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/requestidlecallback": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
+      "integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -23904,6 +24225,13 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rungen": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+      "integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -27178,6 +27506,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/use-memo-one": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.3.tgz",
+      "integrity": "sha512-g66/K7ZQGYrI6dy8GLpVcMsBp4s17xNkYJVSMvTEevGy3nDxHOfE6z8BVE22+5G5x7t3+bhzrlTDB7ObrEE0cQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/packages/AdminConfig/package.json
+++ b/packages/AdminConfig/package.json
@@ -6,6 +6,7 @@
     "build:check": "npm run build && node tools/check-build-assets.js",
     "check": "npm run build:check && npm run test:js-runtime",
     "start": "wp-scripts start",
+    "makepot": "wp i18n make-pot . languages/lerm-admin-config.pot --include='resources/'",
     "test:js-runtime": "node tools/test-js-runtime.js",
     "wp-env:start": "wp-env start",
     "wp-env:start:multisite": "node tools/wp-env-multisite.js start",
@@ -46,6 +47,8 @@
   "devDependencies": {
     "@playwright/test": "^1.52.0",
     "@wordpress/api-fetch": "^7.44.0",
+    "@wordpress/data": "^10.0.0",
+    "@wordpress/i18n": "^5.0.0",
     "@wordpress/env": "^10.19.0",
     "@wordpress/scripts": "^32.0.0",
     "cross-env": "^7.0.3"

--- a/packages/AdminConfig/resources/block-panel/index.js
+++ b/packages/AdminConfig/resources/block-panel/index.js
@@ -15,7 +15,7 @@ const {
 	withValues,
 } = require('../core/schema-state');
 const { createDefaultControlRegistry } = require('../controls');
-const { STORE_NAME } = require('../store');
+const { register: registerStore, STORE_NAME } = require('../store');
 
 const BLOCK_PANEL_CONFIG_GLOBAL = 'lermAdminConfigBlockPanelConfigs';
 const panelInstances = new Map();
@@ -848,6 +848,8 @@ const createPanelComponent = (config, Panel, element) => {
  */
 const registerBlockEditorPanels = (configs = blockPanelConfigsFromWindow()) => {
 	if (typeof window === 'undefined') return false;
+
+	registerStore();
 
 	const wp = window.wp || {};
 	const registerPlugin = wp.plugins && wp.plugins.registerPlugin;

--- a/packages/AdminConfig/resources/i18n/index.js
+++ b/packages/AdminConfig/resources/i18n/index.js
@@ -1,0 +1,72 @@
+// @ts-check
+
+/**
+ * i18n bridge for AdminConfig.
+ *
+ * Re-exports @wordpress/i18n functions so that both the classic admin page
+ * (which reads strings from PHP-localized config during the migration period)
+ * and the block-panel / future React options page can use the same import.
+ *
+ * During the Phase 2 transition, the classic admin-config.js still reads
+ * strings from the `cfg` object injected by wp_localize_script. Once Phase 4
+ * (React options page) is complete, all string lookups will use __() / _x()
+ * exclusively and the PHP-localized config will be removed.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+const i18n = require('@wordpress/i18n');
+
+/**
+ * Look up a translated string.
+ *
+ * @param {string} text   Text to translate.
+ * @param {string} domain Domain to retrieve the translated text.
+ * @returns {string} Translated text.
+ */
+const __ = i18n.__;
+
+/**
+ * Look up a translated string with context.
+ *
+ * @param {string} text    Text to translate.
+ * @param {string} context Context information for the translators.
+ * @param {string} domain  Domain to retrieve the translated text.
+ * @returns {string} Translated text.
+ */
+const _x = i18n._x;
+
+/**
+ * Look up a translated plural string.
+ *
+ * @param {string} single The single form.
+ * @param {string} plural The plural form.
+ * @param {number} number The number to determine the form.
+ * @param {string} domain Domain to retrieve the translated text.
+ * @returns {string} Translated text.
+ */
+const _n = i18n._n;
+
+/**
+ * Return a formatted string.
+ *
+ * @param {string} format The format string.
+ * @param {...unknown} args Arguments for the format string.
+ * @returns {string} Formatted string.
+ */
+const sprintf = i18n.sprintf;
+
+/**
+ * Determine whether @wordpress/i18n has been initialized with translations.
+ *
+ * @returns {boolean}
+ */
+const isRtl = () => i18n.isRTL ? i18n.isRTL() : false;
+
+module.exports = {
+	__,
+	_x,
+	_n,
+	sprintf,
+	isRtl,
+};

--- a/packages/AdminConfig/resources/store/index.js
+++ b/packages/AdminConfig/resources/store/index.js
@@ -1,7 +1,308 @@
 // @ts-check
 
+const { createReduxStore, registerStore } = require('@wordpress/data');
+
 const STORE_NAME = 'lerm/admin-config';
+
+/**
+ * @typedef {'idle'|'loading'|'saving'|'error'|'ready'} SchemaStatus
+ */
+
+/**
+ * @typedef {{
+ *   values: Record<string, unknown>,
+ *   savedValues: Record<string, unknown>,
+ *   status: SchemaStatus,
+ *   errors: Record<string, string|string[]>,
+ *   message: string,
+ * }} SchemaSlice
+ */
+
+/**
+ * @typedef {{
+ *   schemas: Record<string, SchemaSlice>,
+ * }} StoreState
+ */
+
+/** @type {import('@wordpress/data').WPDataStore} */
+const DEFAULT_STATE = {
+	schemas: {},
+};
+
+/**
+ * @param {SchemaSlice|undefined} slice
+ * @returns {boolean}
+ */
+const sliceIsDirty = (slice) => {
+	if (!slice) {
+		return false;
+	}
+
+	return JSON.stringify(slice.values) !== JSON.stringify(slice.savedValues);
+};
+
+/**
+ * @param {SchemaSlice} slice
+ * @param {Record<string, unknown>} values
+ * @returns {SchemaSlice}
+ */
+const withValues = (slice, values) => ({
+	...slice,
+	values,
+	errors: {},
+});
+
+/**
+ * @param {SchemaSlice} slice
+ * @returns {SchemaSlice}
+ */
+const markSaved = (slice) => ({
+	...slice,
+	savedValues: slice.values,
+});
+
+const storeConfig = {
+	reducer(state = DEFAULT_STATE, action) {
+		switch (action.type) {
+			case 'SCHEMA_LOADED':
+				return {
+					...state,
+					schemas: {
+						...state.schemas,
+						[action.schemaId]: {
+							values: action.values,
+							savedValues: action.values,
+							status: 'ready',
+							errors: {},
+							message: '',
+						},
+					},
+				};
+
+			case 'VALUES_CHANGED':
+				return {
+					...state,
+					schemas: {
+						...state.schemas,
+						[action.schemaId]: withValues(
+							state.schemas[action.schemaId] || {
+								values: {},
+								savedValues: {},
+								status: 'idle',
+								errors: {},
+								message: '',
+							},
+							action.values,
+						),
+					},
+				};
+
+			case 'SAVE_STARTED':
+				return {
+					...state,
+					schemas: {
+						...state.schemas,
+						[action.schemaId]: {
+							...(state.schemas[action.schemaId] || {
+								values: {},
+								savedValues: {},
+								status: 'idle',
+								errors: {},
+								message: '',
+							}),
+							status: 'saving',
+							errors: {},
+							message: '',
+						},
+					},
+				};
+
+			case 'SAVE_SUCCEEDED':
+				return {
+					...state,
+					schemas: {
+						...state.schemas,
+						[action.schemaId]: markSaved({
+							...(state.schemas[action.schemaId] || {
+								values: {},
+								savedValues: {},
+								status: 'idle',
+								errors: {},
+								message: '',
+							}),
+							status: 'ready',
+							message: action.message || '',
+						}),
+					},
+				};
+
+			case 'SAVE_FAILED':
+				return {
+					...state,
+					schemas: {
+						...state.schemas,
+						[action.schemaId]: {
+							...(state.schemas[action.schemaId] || {
+								values: {},
+								savedValues: {},
+								status: 'idle',
+								errors: {},
+								message: '',
+							}),
+							status: 'error',
+							errors: action.errors || {},
+							message: action.message || '',
+						},
+					},
+				};
+
+			default:
+				return state;
+		}
+	},
+
+	actions: {
+		/**
+		 * @param {string} schemaId
+		 * @param {Record<string, unknown>} values
+		 */
+		schemaLoaded: (schemaId, values) => ({
+			type: 'SCHEMA_LOADED',
+			schemaId,
+			values,
+		}),
+
+		/**
+		 * @param {string} schemaId
+		 * @param {Record<string, unknown>} values
+		 */
+		valuesChanged: (schemaId, values) => ({
+			type: 'VALUES_CHANGED',
+			schemaId,
+			values,
+		}),
+
+		/**
+		 * @param {string} schemaId
+		 */
+		saveStarted: (schemaId) => ({
+			type: 'SAVE_STARTED',
+			schemaId,
+		}),
+
+		/**
+		 * @param {string} schemaId
+		 * @param {string} [message]
+		 */
+		saveSucceeded: (schemaId, message) => ({
+			type: 'SAVE_SUCCEEDED',
+			schemaId,
+			message,
+		}),
+
+		/**
+		 * @param {string} schemaId
+		 * @param {Record<string, string|string[]>} [errors]
+		 * @param {string} [message]
+		 */
+		saveFailed: (schemaId, errors, message) => ({
+			type: 'SAVE_FAILED',
+			schemaId,
+			errors,
+			message,
+		}),
+	},
+
+	selectors: {
+		/**
+		 * @param {StoreState} state
+		 * @param {string} schemaId
+		 * @returns {SchemaSlice|undefined}
+		 */
+		getSchemaState: (state, schemaId) => state.schemas[schemaId],
+
+		/**
+		 * @param {StoreState} state
+		 * @param {string} schemaId
+		 * @returns {Record<string, unknown>}
+		 */
+		getValues: (state, schemaId) => {
+			const slice = state.schemas[schemaId];
+
+			return slice ? slice.values : {};
+		},
+
+		/**
+		 * @param {StoreState} state
+		 * @param {string} schemaId
+		 * @returns {boolean}
+		 */
+		isDirty: (state, schemaId) => sliceIsDirty(state.schemas[schemaId]),
+
+		/**
+		 * @param {StoreState} state
+		 * @param {string} schemaId
+		 * @returns {SchemaStatus}
+		 */
+		getStatus: (state, schemaId) => {
+			const slice = state.schemas[schemaId];
+
+			return slice ? slice.status : 'idle';
+		},
+
+		/**
+		 * @param {StoreState} state
+		 * @param {string} schemaId
+		 * @returns {Record<string, string|string[]>}
+		 */
+		getErrors: (state, schemaId) => {
+			const slice = state.schemas[schemaId];
+
+			return slice ? slice.errors : {};
+		},
+
+		/**
+		 * @param {StoreState} state
+		 * @param {string} schemaId
+		 * @returns {string}
+		 */
+		getMessage: (state, schemaId) => {
+			const slice = state.schemas[schemaId];
+
+			return slice ? slice.message : '';
+		},
+	},
+};
+
+const store = createReduxStore(STORE_NAME, storeConfig);
+
+/** @type {boolean} */
+let isRegistered = false;
+
+/**
+ * Register the store with wp.data. Safe to call multiple times — registers
+ * only once. Call this during runtime bootstrap (e.g. DOMContentLoaded or
+ * block-panel mount) to ensure wp.data is available.
+ *
+ * In Node.js test environments (no wp.data global), the call is silently
+ * skipped so that the module can still be required for testing.
+ */
+const register = () => {
+	if (isRegistered) {
+		return;
+	}
+
+	try {
+		registerStore(store);
+		isRegistered = true;
+	} catch (_error) {
+		// Silently skip registration in environments without wp.data (e.g. Node.js tests).
+	}
+};
 
 module.exports = {
 	STORE_NAME,
+	storeConfig,
+	store,
+	register,
 };


### PR DESCRIPTION
@
## Summary

Phase 2 of the AdminConfig modernization plan: introduces a wp.data store and i18n bridge as the foundation for future React-driven UI.

## Changes

### wp.data store (`resources/store/index.js`)
- Replaces the name-only constant with a full `createReduxStore` + lazy `registerStore`
- 5 action types: `SCHEMA_LOADED`, `VALUES_CHANGED`, `SAVE_STARTED`, `SAVE_SUCCEEDED`, `SAVE_FAILED`
- 6 selectors: `getSchemaState`, `getValues`, `isDirty`, `getStatus`, `getErrors`, `getMessage`
- Lazy registration via `register()` — safe for Node.js test environments, called during block-panel bootstrap

### i18n bridge (`resources/i18n/index.js`)
- Re-exports `__()`, `_x()`, `_n()`, `sprintf()`, `isRtl()` from `@wordpress/i18n`
- Enables gradual migration away from `wp_localize_script` string injection
- Added `makepot` npm script for `.pot` generation

### Block panel integration
- Calls `registerStore()` during `registerBlockEditorPanels()` to ensure wp.data is available

## Verification

| Check | Result |
|-------|--------|
| PHP syntax | Passed (91 files) |
| PHPCS (WPCS) | 0 errors |
| PHPStan | 106/106 |
| PHPUnit (unit) | 94 tests, 408 assertions |
| PHPUnit (integration) | 5 tests, 24 assertions |
| Playwright E2E (smoke) | 10 passed, 3 skipped |
| JS runtime tests | 17 passed |
| npm build:check | Passed |

No regressions. Block editor E2E test failure is pre-existing (reproduced on clean main).
@