### PR TITLE
feat: replace window.wp globals with @wordpress npm imports in block-panel

### DIFF
--- a/packages/AdminConfig/examples/schema-demo-plugin/src/SchemaDemoPlugin.php
+++ b/packages/AdminConfig/examples/schema-demo-plugin/src/SchemaDemoPlugin.php
@@ -40,6 +40,10 @@ final class SchemaDemoPlugin {
 			$runtime->register( self::taxonomy_schema( $runtime ) );
 		}
 
+		if ( ! $runtime->has( 'acme-demo-block-editor-panel' ) ) {
+			$runtime->register( self::block_editor_panel_schema() );
+		}
+
 		if ( is_multisite() && ! $runtime->has( 'acme-demo-network-settings' ) ) {
 			$runtime->register( self::network_schema() );
 		}
@@ -683,6 +687,60 @@ final class SchemaDemoPlugin {
 								'label' => __( 'Featured', 'lerm-admin-config-demo' ),
 								'slug'  => 'featured-entry',
 							),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private static function block_editor_panel_schema(): array {
+		return array(
+			'id'        => 'acme-demo-block-editor-panel',
+			'title'     => __( 'Demo Block Editor Panel', 'lerm-admin-config-demo' ),
+			'container' => array(
+				'type'       => 'block_editor_panel',
+				'title'      => __( 'Demo Panel', 'lerm-admin-config-demo' ),
+				'post_types' => array( 'post', 'page' ),
+				'capability' => 'edit_post',
+			),
+			'store'     => array(
+				'type' => 'post_meta',
+				'key'  => '_acme_demo_block_panel_settings',
+			),
+			'sections'  => array(
+				'settings' => array(
+					'title'       => __( 'Panel Settings', 'lerm-admin-config-demo' ),
+					'description' => __( 'A standalone block editor panel driven by the block_editor_panel container type. No classic metabox is registered — this schema only appears in the Gutenberg sidebar.', 'lerm-admin-config-demo' ),
+					'fields'      => array(
+						array(
+							'id'          => 'panel_featured',
+							'type'        => 'switcher',
+							'label'       => __( 'Featured entry', 'lerm-admin-config-demo' ),
+							'description' => __( 'Toggles the featured flag through the block editor panel.', 'lerm-admin-config-demo' ),
+							'default'     => 0,
+						),
+						array(
+							'id'          => 'panel_accent',
+							'type'        => 'color',
+							'label'       => __( 'Accent color', 'lerm-admin-config-demo' ),
+							'description' => __( 'A color picker rendered inside the block editor panel.', 'lerm-admin-config-demo' ),
+							'default'     => '#2271b1',
+						),
+						array(
+							'id'          => 'panel_layout',
+							'type'        => 'select',
+							'label'       => __( 'Layout', 'lerm-admin-config-demo' ),
+							'description' => __( 'A select control rendered inside the block editor panel.', 'lerm-admin-config-demo' ),
+							'choices'     => array(
+								'default' => __( 'Default', 'lerm-admin-config-demo' ),
+								'wide'    => __( 'Wide', 'lerm-admin-config-demo' ),
+								'full'    => __( 'Full width', 'lerm-admin-config-demo' ),
+							),
+							'default'     => 'default',
 						),
 					),
 				),

--- a/packages/AdminConfig/languages/lerm-admin-config.pot
+++ b/packages/AdminConfig/languages/lerm-admin-config.pot
@@ -1,0 +1,35 @@
+# Copyright (C) 2026 Lerm
+# This file is distributed under the GPL-2.0-or-later.
+msgid ""
+msgstr ""
+"Project-Id-Version: Lerm Admin Config 0.4.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/AdminConfig\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-06-07T13:45:47+02:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: lerm-admin-config\n"
+
+#. Plugin Name of the plugin
+#: lerm-admin-config.php
+msgid "Lerm Admin Config"
+msgstr ""
+
+#. Plugin URI of the plugin
+#: lerm-admin-config.php
+msgid "https://lerm.net"
+msgstr ""
+
+#. Description of the plugin
+#: lerm-admin-config.php
+msgid "Schema-driven WordPress admin configuration infrastructure for options, metadata, and profile surfaces."
+msgstr ""
+
+#. Author of the plugin
+#: lerm-admin-config.php
+msgid "Lerm"
+msgstr ""

--- a/packages/AdminConfig/package-lock.json
+++ b/packages/AdminConfig/package-lock.json
@@ -8,6 +8,7 @@
       "devDependencies": {
         "@playwright/test": "^1.52.0",
         "@wordpress/api-fetch": "^7.44.0",
+        "@wordpress/components": "^28.0.0",
         "@wordpress/data": "^10.0.0",
         "@wordpress/env": "^10.19.0",
         "@wordpress/i18n": "^5.0.0",
@@ -28,6 +29,101 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@ariakit/components": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.2.tgz",
+      "integrity": "sha512-tvh2P0x1cJnoPXnmDEJwdRk3z7x6cTB8ArctcZdAUXlRg9tuwW/rJoBFJMzD5qMI9CDDlQ3Zctx58HvENw4BYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/store": "0.1.2",
+        "@ariakit/utils": "0.1.2"
+      }
+    },
+    "node_modules/@ariakit/react": {
+      "version": "0.4.29",
+      "resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.29.tgz",
+      "integrity": "sha512-SLXlsddWHSwfUol4Yi0zULlalNWjzWjpS3zg7B7aaPd64saONQ5ktWf9KMxqBklcpjMLeF2dB9BAHAvpPVdCIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-components": "0.1.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ariakit"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-components": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.1.2.tgz",
+      "integrity": "sha512-SM+SPMAVlOZmGAfWNBza+0k9y4mkA5/dJhDoOyhE96cbNARy665uLdwowSJl1JGuFfcZzuzAwGon7f/rYeyfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/components": "0.1.2",
+        "@ariakit/react-store": "0.1.2",
+        "@ariakit/react-utils": "0.1.2",
+        "@ariakit/store": "0.1.2",
+        "@ariakit/utils": "0.1.2",
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-store": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.2.tgz",
+      "integrity": "sha512-1r1Gn0tqhnOS0LFvHNGzn5/8C5aOANO5vb0Gxh94oR/be4zwCSE2zfQjOjRfpL+BBDhOcProME2+G6UslEJxbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/react-utils": "0.1.2",
+        "@ariakit/store": "0.1.2",
+        "@ariakit/utils": "0.1.2",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/react-utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.1.2.tgz",
+      "integrity": "sha512-Rnl6D1542Mqu80xK++oUv1JXS0PtNmKXd9nkdud5nyvySiBDTrmPqRW44/D+5GbuZrboreQuY3tPYwKL7a7onQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/store": "0.1.2",
+        "@ariakit/utils": "0.1.2"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ariakit/store": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.2.tgz",
+      "integrity": "sha512-SS7bV4+a+1q9M9i0WV6DD4P/ypRKlCvII8soo2UMe1yuaxZA/Fc0htHe+EZwjJ6TMLjHfHh2TDSnXyrjC7QImA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ariakit/utils": "0.1.2"
+      }
+    },
+    "node_modules/@ariakit/utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.2.tgz",
+      "integrity": "sha512-lBJhtBWpKjIck/9i7G8cahvaUgLsyGklI/Pjv+VtY9KTzyuzX5GpRbbLKMS/e1qLnFPS4C3CybYB70b1bVcAkw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
@@ -2442,6 +2538,209 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/serialize": "^1.3.3",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emotion/babel-plugin/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/css": {
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
+      "integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.13.5",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/sheet": "^1.4.0",
+        "@emotion/utils": "^1.4.2"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
+        "@emotion/weak-memoize": "^0.4.0",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/hash": "^0.9.2",
+        "@emotion/memoize": "^0.9.0",
+        "@emotion/unitless": "^0.10.0",
+        "@emotion/utils": "^1.4.2",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.14.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
+      "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/is-prop-valid": "^1.3.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.50.2",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.50.2.tgz",
@@ -2842,6 +3141,48 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.3.6",
@@ -7595,6 +7936,20 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/gradient-parser": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
+      "integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/highlight-words-core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/highlight-words-core/-/highlight-words-core-1.2.1.tgz",
+      "integrity": "sha512-9VZUA5omXBfn+hDxFjUDu1FOJTBM3LmvqfDey+Z6Aa8B8/JmF5SMj6FBrjfgJ/Q3YXOZd3qyTDfJyMZSs/wCUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -8647,6 +9002,26 @@
         "win32"
       ]
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -8853,6 +9228,42 @@
         "webpack-dev-server": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@wordpress/a11y": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.48.0.tgz",
+      "integrity": "sha512-MXwBc2sYaemZCn1dqVutTbLdM6iy4bx/HS9hHR/+pRpaSVJUlguZ1aQ0BaoIbE4u0uOezGGc5d2bDfWCti3Dww==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/dom-ready": "^4.48.0",
+        "@wordpress/i18n": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.0.tgz",
+      "integrity": "sha512-IXGGUJqN6b7QddU0dZB3HLJKu6uDQuhLsrrzYpUYTjDhfa43XEaikA9xHNgZhqzRtOVYqsNHVliWcISvJ/xjZQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@tannin/sprintf": "^1.3.2",
+        "@wordpress/hooks": "^4.48.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/api-fetch": {
@@ -9141,6 +9552,90 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/components": {
+      "version": "28.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.13.0.tgz",
+      "integrity": "sha512-JaGcXYtFCvHqa62dtxMAMhu6afvefFOuwfUTNiLYg60CA4UDITt6gf+qhpvKNOzVg4qQRw10o/nryrOMoMAEEg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.10",
+        "@babel/runtime": "7.25.7",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@types/gradient-parser": "0.1.3",
+        "@types/highlight-words-core": "1.2.1",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "*",
+        "@wordpress/compose": "*",
+        "@wordpress/date": "*",
+        "@wordpress/deprecated": "*",
+        "@wordpress/dom": "*",
+        "@wordpress/element": "*",
+        "@wordpress/escape-html": "*",
+        "@wordpress/hooks": "*",
+        "@wordpress/html-entities": "*",
+        "@wordpress/i18n": "*",
+        "@wordpress/icons": "*",
+        "@wordpress/is-shallow-equal": "*",
+        "@wordpress/keycodes": "*",
+        "@wordpress/primitives": "*",
+        "@wordpress/private-apis": "*",
+        "@wordpress/rich-text": "*",
+        "@wordpress/warning": "*",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.1.9",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.1",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/components/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@wordpress/components/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wordpress/compose": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
@@ -9241,6 +9736,22 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/date": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.48.0.tgz",
+      "integrity": "sha512-HgXtYAD2IOrPDY83xzkT/8abYj2nMlkbC+lfSpB4lExlSVrIbz5oYUtktH8k5EBZjVBMFsE7mdMQyQjUeCQbeQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/deprecated": "^4.48.0",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.40"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
       "version": "6.45.0",
       "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.45.0.tgz",
@@ -9288,6 +9799,17 @@
       "dependencies": {
         "@wordpress/deprecated": "^4.48.0"
       },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/dom-ready": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.48.0.tgz",
+      "integrity": "sha512-jtH9/4FBTsfYLJDzgiXs41nceTrfvuLXqaWa5IN8drHvXZde6Dhz78m3KCZLrOB5DEE1tbyBNyZkcWM8HNVZ0Q==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
       "engines": {
         "node": ">=18.12.0",
         "npm": ">=8.19.2"
@@ -9474,6 +9996,17 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@wordpress/html-entities": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.48.0.tgz",
+      "integrity": "sha512-KGxdaLC36wE10GybSfjYGcyWiy+KQCYheB6T8jhZhQ9mlf2Zwx6aJgfZm/L6BLwNN33Efx+sJY3nvMIxI5UwnA==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/i18n": {
       "version": "5.26.0",
       "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
@@ -9502,6 +10035,46 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@wordpress/icons": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+      "integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/primitives": "^4.48.0",
+        "change-case": "4.1.2"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
     },
     "node_modules/@wordpress/is-shallow-equal": {
       "version": "5.48.0",
@@ -9633,6 +10206,45 @@
         "prettier": ">=3"
       }
     },
+    "node_modules/@wordpress/primitives": {
+      "version": "4.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.48.0.tgz",
+      "integrity": "sha512-dfF7IZotIqb6LUiGs7oPwKbSF8RPoC0JDSIrtxvgwFA/yvbc/pDIp/Zs0O8GvxZNxu4JIVnKskOhoLq7lAeziQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/element": "^8.0.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
     "node_modules/@wordpress/priority-queue": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.48.0.tgz",
@@ -9675,6 +10287,76 @@
       },
       "peerDependencies": {
         "redux": ">=4"
+      }
+    },
+    "node_modules/@wordpress/rich-text": {
+      "version": "7.48.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.48.0.tgz",
+      "integrity": "sha512-rMiTTpRnpdynL9BnuI2MkSXzd12Js8gYSnlbVwxNNKNeFEXT+3Ah2oNCGvSb82pD/73Bl5BIGC5395D5a3X9yw==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@wordpress/a11y": "^4.48.0",
+        "@wordpress/compose": "^8.1.0",
+        "@wordpress/data": "^10.48.0",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/dom": "^4.48.0",
+        "@wordpress/element": "^8.0.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "@wordpress/i18n": "^6.21.0",
+        "@wordpress/keycodes": "^4.48.0",
+        "@wordpress/private-apis": "^1.48.0",
+        "colord": "2.9.3",
+        "memize": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
+      "integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@types/react": "^18.3.27",
+        "@types/react-dom": "^18.3.1",
+        "@wordpress/deprecated": "^4.48.0",
+        "@wordpress/escape-html": "^3.48.0",
+        "change-case": "^4.1.2",
+        "is-plain-object": "^5.0.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/@wordpress/rich-text/node_modules/@wordpress/i18n": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.0.tgz",
+      "integrity": "sha512-IXGGUJqN6b7QddU0dZB3HLJKu6uDQuhLsrrzYpUYTjDhfa43XEaikA9xHNgZhqzRtOVYqsNHVliWcISvJ/xjZQ==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@tannin/sprintf": "^1.3.2",
+        "@wordpress/hooks": "^4.48.0",
+        "gettext-parser": "^1.3.1",
+        "memize": "^2.1.0",
+        "tannin": "^1.2.0"
+      },
+      "bin": {
+        "pot-to-php": "tools/pot-to-php.js"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/scripts": {
@@ -11105,6 +11787,49 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/babel-plugin-macros/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.17",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
@@ -12218,6 +12943,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -13062,6 +13797,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debounce": {
@@ -15484,6 +16230,13 @@
         "find-process": "bin/find-process.js"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -15652,6 +16405,34 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {
@@ -16161,6 +16942,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/gradient-parser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
+      "integrity": "sha512-+uPlcVbjrKOnTzvz0MjTj7BfACj8OmxIa1moIjJV7btvhUMSJk0D47RfDCgDrZE3dYMz9Cf5xKJwnrKLjUq0KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -16311,6 +17101,30 @@
         "capital-case": "^1.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/highlight-words-core": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/highlight-words-core/-/highlight-words-core-1.2.3.tgz",
+      "integrity": "sha512-m1O9HW3/GNHxzSIXWw1wCNXXsgLlxrP0OI6+ycGUhiUHkikqW3OrwVHz+lxeNBe5yqLESdIcj8PowHQ2zLvUvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
@@ -20930,6 +21744,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mousetrap": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -23555,6 +24409,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/re-resizable": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.11.2.tgz",
+      "integrity": "sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -23566,6 +24431,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-colorful": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.7.0.tgz",
+      "integrity": "sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {
@@ -26244,6 +27120,13 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -27516,6 +28399,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/packages/AdminConfig/package.json
+++ b/packages/AdminConfig/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@playwright/test": "^1.52.0",
     "@wordpress/api-fetch": "^7.44.0",
+    "@wordpress/components": "^28.0.0",
     "@wordpress/data": "^10.0.0",
     "@wordpress/i18n": "^5.0.0",
     "@wordpress/env": "^10.19.0",

--- a/packages/AdminConfig/resources/admin/admin-config.js
+++ b/packages/AdminConfig/resources/admin/admin-config.js
@@ -30,7 +30,15 @@ let confirmDialog;
 	 * @param {string} message
 	 * @returns {Promise<boolean>}
 	 */
+	let dialogActive = false;
+
 	confirmDialog = (message) => {
+		if (dialogActive) {
+			return Promise.resolve(false);
+		}
+
+		dialogActive = true;
+
 		return new Promise((resolve) => {
 			const container = document.createElement('div');
 			document.body.appendChild(container);
@@ -42,6 +50,7 @@ let confirmDialog;
 					// If unmount fails, just remove the container.
 				}
 				container.remove();
+				dialogActive = false;
 				resolve(result);
 			};
 

--- a/packages/AdminConfig/resources/admin/admin-config.js
+++ b/packages/AdminConfig/resources/admin/admin-config.js
@@ -8,6 +8,7 @@
 const { resolveAdminConfig } = require('../core/config');
 const { createFormStateHelpers } = require('./form-state');
 const { createAdminConfigTransport } = require('./transport');
+const { __ } = require('../i18n');
 
 /** @type {any} */ const wp = /** @type {any} */ (window['wp']);
 
@@ -20,20 +21,6 @@ const { createAdminConfigTransport } = require('./transport');
 	 * @typedef {{
 	 *   restUrl?: string, restNonce?: string,
 	 *   codeEditor: object|null,
-	 *   selectMedia: string, useMedia: string, noMedia: string,
-	 *   selectImages: string, useImages: string, noGallery: string,
-	 *   searchPrompt: string, searchMinPrompt: string, loadingResults: string,
-	 *   noResults: string, loadMoreResults: string,
-	 *   clearSelection: string, removeSelection: string,
-	 *   saving: string, resetting: string,
-	 *   saveSuccess: string, saveError: string,
-	 *   resetError: string, resetAllSuccess: string, resetSectionSuccess: string,
-	 *   importSuccess: string, importError: string, exportSuccess: string,
-	 *   statusReady: string, statusDirty: string, statusSaving: string,
-	 *   statusResetting: string, statusSaved: string, statusError: string,
-	 *   confirmResetAll: string, confirmResetSection: string,
-	 *   confirmRemoveItem: string, confirmImport: string,
-	 *   debugCopy: string, debugCopied: string
 	 * }} LermConfig
 	 */
 
@@ -1058,7 +1045,7 @@ const { createAdminConfigTransport } = require('./transport');
 			return requestRest(`schemas/${params.schemaId}/data-source`, { method: 'POST', body });
 		}
 
-		return Promise.resolve({ success: false, data: { message: cfg.saveError } });
+		return Promise.resolve({ success: false, data: { message: __('Unable to save the settings right now.', 'lerm-admin-config') } });
 	};
 
 	/**
@@ -1196,8 +1183,8 @@ const { createAdminConfigTransport } = require('./transport');
 				pill.appendChild(dom.create('button', {
 					type: 'button',
 					class: 'lerm-ajax-select__pill-remove',
-					'aria-label': cfg.removeSelection,
-					title: cfg.removeSelection,
+					'aria-label': __('Remove selection', 'lerm-admin-config'),
+					title: __('Remove selection', 'lerm-admin-config'),
 					onclick: (event) => {
 						event.preventDefault();
 						instance.selections = instance.selections.filter((current) => current.value !== selection.value);
@@ -1223,7 +1210,7 @@ const { createAdminConfigTransport } = require('./transport');
 
 		if (!options.length) {
 			closeAjaxSelectDropdown(instance);
-			setAjaxSelectStatus(instance, cfg.noResults);
+			setAjaxSelectStatus(instance, __('No matching results found.', 'lerm-admin-config'));
 			return;
 		}
 
@@ -1248,7 +1235,7 @@ const { createAdminConfigTransport } = require('./transport');
 							renderAjaxSelectSelections(instance, true);
 							instance.search.value = '';
 							instance.currentQuery = '';
-							setAjaxSelectStatus(instance, cfg.searchPrompt);
+							setAjaxSelectStatus(instance, __('Start typing to search.', 'lerm-admin-config'));
 							closeAjaxSelectDropdown(instance);
 							return;
 						}
@@ -1257,7 +1244,7 @@ const { createAdminConfigTransport } = require('./transport');
 						renderAjaxSelectSelections(instance, true);
 						instance.search.value = '';
 						instance.currentQuery = '';
-						setAjaxSelectStatus(instance, cfg.searchPrompt);
+						setAjaxSelectStatus(instance, __('Start typing to search.', 'lerm-admin-config'));
 						closeAjaxSelectDropdown(instance);
 					},
 				}, [option.label]),
@@ -1273,7 +1260,7 @@ const { createAdminConfigTransport } = require('./transport');
 						event.preventDefault();
 						loadAjaxSelectOptions(instance, instance.currentQuery, Math.max(2, Math.ceil(instance.options.length / Math.max(instance.perPage, 1)) + 1), true);
 					},
-				}, [cfg.loadMoreResults]),
+				}, [__('Load more', 'lerm-admin-config')]),
 			]));
 		}
 
@@ -1291,7 +1278,7 @@ const { createAdminConfigTransport } = require('./transport');
 		if (!hasRestTransport() || !instance.schemaId || !instance.source) return Promise.resolve();
 
 		instance.currentQuery = query;
-		setAjaxSelectStatus(instance, cfg.loadingResults);
+		setAjaxSelectStatus(instance, __('Loading results...', 'lerm-admin-config'));
 
 		return requestDataSource(instance.form, {
 			schemaId: instance.schemaId,
@@ -1302,7 +1289,7 @@ const { createAdminConfigTransport } = require('./transport');
 			selected: !query && 1 === page ? instance.selections.map((selection) => selection.value) : [],
 		}).then((response) => {
 			if (!response?.success) {
-				setAjaxSelectStatus(instance, response?.data?.message || cfg.saveError);
+				setAjaxSelectStatus(instance, response?.data?.message || __('Unable to save the settings right now.', 'lerm-admin-config'));
 				return;
 			}
 
@@ -1312,9 +1299,9 @@ const { createAdminConfigTransport } = require('./transport');
 
 			instance.more = !!response?.data?.more;
 			renderAjaxSelectOptions(instance, append ? instance.options.concat(/** @type {AjaxSelectOption[]} */ (nextOptions)) : /** @type {AjaxSelectOption[]} */ (nextOptions));
-			setAjaxSelectStatus(instance, nextOptions.length ? cfg.searchPrompt : cfg.noResults);
+			setAjaxSelectStatus(instance, nextOptions.length ? __('Start typing to search.', 'lerm-admin-config') : __('No matching results found.', 'lerm-admin-config'));
 		}).catch(() => {
-			setAjaxSelectStatus(instance, cfg.saveError);
+			setAjaxSelectStatus(instance, __('Unable to save the settings right now.', 'lerm-admin-config'));
 		});
 	};
 
@@ -1421,7 +1408,7 @@ const { createAdminConfigTransport } = require('./transport');
 				closeAjaxSelectDropdown(instance);
 				setAjaxSelectStatus(
 					instance,
-					instance.minSearchLength > 0 ? cfg.searchMinPrompt : cfg.searchPrompt
+					instance.minSearchLength > 0 ? __('Type more characters to search.', 'lerm-admin-config') : __('Start typing to search.', 'lerm-admin-config')
 				);
 				return;
 			}
@@ -1603,8 +1590,8 @@ const { createAdminConfigTransport } = require('./transport');
 
 				/** @type {any} */
 				const config = {
-					title: cfg.selectFile || cfg.selectMedia,
-					button: { text: cfg.useFile || cfg.useMedia },
+					title: __('Choose file', 'lerm-admin-config'),
+					button: { text: __('Use this file', 'lerm-admin-config') },
 					multiple: false,
 				};
 
@@ -1700,7 +1687,7 @@ const { createAdminConfigTransport } = require('./transport');
 			/** @type {HTMLElement} */ (dom.find('.lerm-media-select', container)).addEventListener('click', (e) => {
 				e.preventDefault();
 				if (frame) { frame.open(); return; }
-				frame = wp.media({ title: cfg.selectMedia, button: { text: cfg.useMedia }, library: { type: 'image' }, multiple: false });
+				frame = wp.media({ title: __('Choose image', 'lerm-admin-config'), button: { text: __('Use this image', 'lerm-admin-config') }, library: { type: 'image' }, multiple: false });
 				frame.on('select', () => {
 					/** @type {WPAttachment} */
 					const attachment = frame.state().get('selection').first().toJSON();
@@ -1775,7 +1762,7 @@ const { createAdminConfigTransport } = require('./transport');
 			/** @type {HTMLElement} */ (dom.find('.lerm-gallery-select', container)).addEventListener('click', (e) => {
 				e.preventDefault();
 				if (frame) { frame.open(); return; }
-				frame = wp.media({ title: cfg.selectImages, button: { text: cfg.useImages }, library: { type: 'image' }, multiple: true });
+				frame = wp.media({ title: __('Choose images', 'lerm-admin-config'), button: { text: __('Use these images', 'lerm-admin-config') }, library: { type: 'image' }, multiple: true });
 				frame.on('select', () => {
 					/** @type {WPAttachment[]} */
 					const attachments = frame.state().get('selection').toJSON();
@@ -1981,7 +1968,7 @@ const { createAdminConfigTransport } = require('./transport');
 				const btn = /** @type {HTMLElement} */ (e.target)?.closest('[data-lerm-group-remove]');
 				if (!btn || !list.contains(btn)) return;
 				e.preventDefault();
-				if (!window.confirm(cfg.confirmRemoveItem)) return;
+				if (!window.confirm(__('Remove this item?', 'lerm-admin-config'))) return;
     			/** @type {HTMLElement} */ (btn.closest('[data-lerm-group-item]')).remove();
 				renumberGroupItems(groupEl);
 				syncDirtyState(/** @type {HTMLFormElement} */(groupEl.closest('form')));
@@ -2276,19 +2263,19 @@ const { createAdminConfigTransport } = require('./transport');
 			if (!button || !json) return;
 
 			button.addEventListener('click', () => {
-				const defaultLabel = button.textContent || cfg.debugCopy || 'Copy JSON';
+				const defaultLabel = button.textContent || __('Copy JSON', 'lerm-admin-config');
 
 				copyText(json.textContent || '')
 					.then(() => {
-						button.textContent = cfg.debugCopied || 'Copied';
+						button.textContent = __('Copied', 'lerm-admin-config');
 						window.setTimeout(() => {
-							button.textContent = cfg.debugCopy || defaultLabel;
+							button.textContent = __('Copy JSON', 'lerm-admin-config') || defaultLabel;
 						}, 1400);
 					})
 					.catch(() => {
-						button.textContent = cfg.saveError || defaultLabel;
+						button.textContent = __('Unable to save the settings right now.', 'lerm-admin-config') || defaultLabel;
 						window.setTimeout(() => {
-							button.textContent = cfg.debugCopy || defaultLabel;
+							button.textContent = __('Copy JSON', 'lerm-admin-config') || defaultLabel;
 						}, 1400);
 					});
 			});
@@ -2433,7 +2420,7 @@ const { createAdminConfigTransport } = require('./transport');
 		if (statusTimer) clearTimeout(statusTimer);
 		statusTimer = setTimeout(() => {
 			const dirty = pageIsDirty(form);
-			setStatus(form, dirty ? 'dirty' : 'idle', dirty ? cfg.statusDirty : cfg.statusReady);
+			setStatus(form, dirty ? 'dirty' : 'idle', dirty ? __('Unsaved changes', 'lerm-admin-config') : __('Synced', 'lerm-admin-config'));
 		}, 1800);
 	};
 
@@ -2445,7 +2432,7 @@ const { createAdminConfigTransport } = require('./transport');
 		if (statusTimer) clearTimeout(statusTimer);
 		setData(form, 'lerm-dirty', dirty ? '1' : '0');
 		const pageDirty = pageIsDirty(form);
-		setStatus(form, pageDirty ? 'dirty' : 'idle', pageDirty ? cfg.statusDirty : cfg.statusReady);
+		setStatus(form, pageDirty ? 'dirty' : 'idle', pageDirty ? __('Unsaved changes', 'lerm-admin-config') : __('Synced', 'lerm-admin-config'));
 	};
 
 	/** @param {HTMLFormElement} form */
@@ -2476,7 +2463,7 @@ const { createAdminConfigTransport } = require('./transport');
 			return requestRest(path, { method: 'POST', body });
 		}
 
-		return Promise.resolve({ success: false, data: { message: cfg.saveError } });
+		return Promise.resolve({ success: false, data: { message: __('Unable to save the settings right now.', 'lerm-admin-config') } });
 	};
 
 	/**
@@ -2514,7 +2501,7 @@ const { createAdminConfigTransport } = require('./transport');
 			return requestRest(path, { method: 'POST', body });
 		}
 
-		return Promise.resolve({ success: false, data: { message: cfg.saveError } });
+		return Promise.resolve({ success: false, data: { message: __('Unable to save the settings right now.', 'lerm-admin-config') } });
 	};
 
 	// ─── Value Application ────────────────────────────────────────────────────
@@ -3002,7 +2989,7 @@ const { createAdminConfigTransport } = require('./transport');
 
 		const focusForm = activePageForm(form) || form;
 		applyFieldErrors(focusForm, fieldErrors, true);
-		setStatus(focusForm, 'error', response?.data?.message || cfg.saveError);
+		setStatus(focusForm, 'error', response?.data?.message || __('Unable to save the settings right now.', 'lerm-admin-config'));
 	};
 
 	// ─── Backup Tools ─────────────────────────────────────────────────────────
@@ -3015,13 +3002,13 @@ const { createAdminConfigTransport } = require('./transport');
 				e.preventDefault();
 				request(form, 'export').then(response => {
 					if (!response?.success) {
-						setStatus(form, 'error', response?.data?.message || cfg.saveError);
+						setStatus(form, 'error', response?.data?.message || __('Unable to save the settings right now.', 'lerm-admin-config'));
 						return;
 					}
 					/** @type {HTMLInputElement} */ (dom.find('[data-lerm-backup-export-output]', form)).value = response.data.json || '';
-					setStatus(form, 'success', response.data.message || cfg.exportSuccess);
+					setStatus(form, 'success', response.data.message || __('Current settings snapshot generated.', 'lerm-admin-config'));
 					queueReadyStatus(form);
-				}).catch(() => setStatus(form, 'error', cfg.saveError));
+				}).catch(() => setStatus(form, 'error', __('Unable to save the settings right now.', 'lerm-admin-config')));
 			});
 		}
 
@@ -3029,15 +3016,15 @@ const { createAdminConfigTransport } = require('./transport');
 		if (importBtn) {
 			importBtn.addEventListener('click', (e) => {
 				e.preventDefault();
-				if (!window.confirm(cfg.confirmImport)) return;
+				if (!window.confirm(__('Importing will overwrite the current saved settings. Continue?', 'lerm-admin-config'))) return;
 				const json = String(/** @type {HTMLInputElement|null} */(dom.find('[data-lerm-backup-import-input]', form))?.value ?? '');
 				pageForms(form).forEach((pageForm) => clearFieldErrors(pageForm));
-				setBusyAcrossPage(form, true, cfg.resetting);
-				setStatus(form, 'saving', cfg.statusSaving);
+				setBusyAcrossPage(form, true, __('Resetting...', 'lerm-admin-config'));
+				setStatus(form, 'saving', __('Saving...', 'lerm-admin-config'));
 				request(form, 'import', { backup_json: json })
-					.then(response => handlePageSaveResponse(form, response, cfg.importSuccess))
-					.catch(() => setStatus(form, 'error', cfg.importError))
-					.finally(() => setBusyAcrossPage(form, false, cfg.resetting));
+					.then(response => handlePageSaveResponse(form, response, __('Settings imported successfully.', 'lerm-admin-config')))
+					.catch(() => setStatus(form, 'error', __('Unable to import the provided settings JSON.', 'lerm-admin-config')))
+					.finally(() => setBusyAcrossPage(form, false, __('Resetting...', 'lerm-admin-config')));
 			});
 		}
 	};
@@ -3052,7 +3039,7 @@ const { createAdminConfigTransport } = require('./transport');
 	const handleSaveResponse = (form, response, successMsg, partialFieldIds = null) => {
 		if (!response?.success) {
 			applyFieldErrors(form, /** @type {Record<string, string|string[]>} */ (response?.data?.errors ?? response?.data?.fieldErrors ?? {}));
-			setStatus(form, 'error', response?.data?.message || cfg.saveError);
+			setStatus(form, 'error', response?.data?.message || __('Unable to save the settings right now.', 'lerm-admin-config'));
 			return;
 		}
 		clearFieldErrors(form);
@@ -3093,29 +3080,29 @@ const { createAdminConfigTransport } = require('./transport');
 			e.preventDefault();
 			triggerEditorSaveAcrossPage(form);
 			pageForms(form).forEach((pageForm) => clearFieldErrors(pageForm));
-			setBusyAcrossPage(form, true, cfg.saving);
-			setStatus(form, 'saving', cfg.statusSaving);
+			setBusyAcrossPage(form, true, __('Saving...', 'lerm-admin-config'));
+			setStatus(form, 'saving', __('Saving...', 'lerm-admin-config'));
 			requestPage(form, 'save')
-				.then(r => handlePageSaveResponse(form, r, cfg.saveSuccess))
-				.catch(() => setStatus(form, 'error', cfg.saveError))
-				.finally(() => setBusyAcrossPage(form, false, cfg.saving));
+				.then(r => handlePageSaveResponse(form, r, __('Settings saved.', 'lerm-admin-config')))
+				.catch(() => setStatus(form, 'error', __('Unable to save the settings right now.', 'lerm-admin-config')))
+				.finally(() => setBusyAcrossPage(form, false, __('Saving...', 'lerm-admin-config')));
 		});
 
 		dom.findAll('[data-lerm-reset]', form).forEach(btn => {
 			btn.addEventListener('click', (e) => {
 				e.preventDefault();
 				const scope = getData(btn, 'lerm-reset') === 'all' ? 'all' : 'section';
-				if (!window.confirm(scope === 'all' ? cfg.confirmResetAll : cfg.confirmResetSection)) return;
+				if (!window.confirm(scope === 'all' ? __('Reset every section on this page back to default values?', 'lerm-admin-config') : __('Reset the current page back to its default values?', 'lerm-admin-config'))) return;
 				triggerEditorSave(form);
 				clearFieldErrors(form);
-				setBusy(form, true, cfg.resetting);
-				setStatus(form, 'resetting', cfg.statusResetting);
+				setBusy(form, true, __('Resetting...', 'lerm-admin-config'));
+				setStatus(form, 'resetting', __('Resetting...', 'lerm-admin-config'));
 				request(form, 'reset', { reset_scope: scope })
 					.then(r => {
 						const partialFieldIds = r?.data?.scope === 'subsection'
 							? Object.keys(/** @type {Record<string, unknown>} */ (r.data.values ?? {}))
 							: null;
-						handleSaveResponse(form, r, scope === 'all' ? cfg.resetAllSuccess : cfg.resetSectionSuccess, partialFieldIds);
+						handleSaveResponse(form, r, scope === 'all' ? __('All sections have been reset to defaults.', 'lerm-admin-config') : __('The current page has been reset to defaults.', 'lerm-admin-config'), partialFieldIds);
 						// After a full reset, reload values for every other tab form too.
 						if (scope === 'all' && r?.success) {
 							dom.findAll('.lerm-settings-form').forEach(otherEl => {
@@ -3133,8 +3120,8 @@ const { createAdminConfigTransport } = require('./transport');
 							});
 						}
 					})
-					.catch(() => setStatus(form, 'error', cfg.resetError))
-					.finally(() => setBusy(form, false, cfg.saving));
+					.catch(() => setStatus(form, 'error', __('Unable to reset the settings right now.', 'lerm-admin-config')))
+					.finally(() => setBusy(form, false, __('Saving...', 'lerm-admin-config')));
 			});
 		});
 
@@ -3435,7 +3422,7 @@ const { createAdminConfigTransport } = require('./transport');
 					if (nonceInput) nonceInput.value = activePanel.getAttribute('data-tab-nonce') ?? '';
 
 					const dirty = pageIsDirty(activeForm);
-					setStatus(activeForm, dirty ? 'dirty' : 'idle', dirty ? cfg.statusDirty : cfg.statusReady);
+					setStatus(activeForm, dirty ? 'dirty' : 'idle', dirty ? __('Unsaved changes', 'lerm-admin-config') : __('Synced', 'lerm-admin-config'));
 				}
 			}
 

--- a/packages/AdminConfig/resources/admin/admin-config.js
+++ b/packages/AdminConfig/resources/admin/admin-config.js
@@ -45,12 +45,13 @@ let confirmDialog;
 				resolve(result);
 			};
 
-			render(
-				createElement(
-					Modal,
-					{
-						title: __('Confirm', 'lerm-admin-config'),
-						onRequestClose: () => cleanup(false),
+			try {
+				render(
+					createElement(
+						Modal,
+						{
+							title: __('Confirm', 'lerm-admin-config'),
+							onRequestClose: () => cleanup(false),
 					},
 					createElement('p', null, message),
 					createElement(
@@ -77,7 +78,13 @@ let confirmDialog;
 				),
 				container
 			);
-		});
+		} catch (_renderErr) {
+			// If the initial render fails (e.g., incompatible React version),
+			// clean up the container and resolve so the caller doesn't hang.
+			cleanup(false);
+			return;
+		}
+	});
 	};
 })();
 

--- a/packages/AdminConfig/resources/admin/admin-config.js
+++ b/packages/AdminConfig/resources/admin/admin-config.js
@@ -10,6 +10,77 @@ const { createFormStateHelpers } = require('./form-state');
 const { createAdminConfigTransport } = require('./transport');
 const { __ } = require('../i18n');
 
+// ─── Confirm Dialog (wp.components.Modal bridge for vanilla JS) ──────
+let confirmDialog;
+(function buildConfirmDialog() {
+	let element, components;
+	try {
+		element = require('@wordpress/element');
+		components = require('@wordpress/components');
+	} catch (_e) {
+		confirmDialog = (message) => Promise.resolve(window.confirm(message));
+		return;
+	}
+
+	const { createElement, render } = element;
+	const { Button, Modal } = components;
+
+	/**
+	 * Show a confirmation dialog using wp.components.Modal.
+	 * @param {string} message
+	 * @returns {Promise<boolean>}
+	 */
+	confirmDialog = (message) => {
+		return new Promise((resolve) => {
+			const container = document.createElement('div');
+			document.body.appendChild(container);
+
+			const cleanup = (/** @type {boolean} */ result) => {
+				try {
+					render(null, container);
+				} catch (_err) {
+					// If unmount fails, just remove the container.
+				}
+				container.remove();
+				resolve(result);
+			};
+
+			render(
+				createElement(
+					Modal,
+					{
+						title: __('Confirm', 'lerm-admin-config'),
+						onRequestClose: () => cleanup(false),
+					},
+					createElement('p', null, message),
+					createElement(
+						'div',
+						{ style: { display: 'flex', justifyContent: 'flex-end', gap: '8px', marginTop: '16px' } },
+						createElement(
+							Button,
+							{
+								variant: 'secondary',
+								onClick: () => cleanup(false),
+							},
+							__('Cancel', 'lerm-admin-config')
+						),
+						createElement(
+							Button,
+							{
+								variant: 'primary',
+								isDestructive: true,
+								onClick: () => cleanup(true),
+							},
+							__('Confirm', 'lerm-admin-config')
+						)
+					)
+				),
+				container
+			);
+		});
+	};
+})();
+
 /** @type {any} */ const wp = /** @type {any} */ (window['wp']);
 
 (function () {
@@ -1964,11 +2035,11 @@ const { __ } = require('../i18n');
 				syncDirtyState(/** @type {HTMLFormElement} */(groupEl.closest('form')));
 			});
 
-			list.addEventListener('click', (e) => {
+			list.addEventListener('click', async (e) => {
 				const btn = /** @type {HTMLElement} */ (e.target)?.closest('[data-lerm-group-remove]');
 				if (!btn || !list.contains(btn)) return;
 				e.preventDefault();
-				if (!window.confirm(__('Remove this item?', 'lerm-admin-config'))) return;
+				if (!await confirmDialog(__('Remove this item?', 'lerm-admin-config'))) return;
     			/** @type {HTMLElement} */ (btn.closest('[data-lerm-group-item]')).remove();
 				renumberGroupItems(groupEl);
 				syncDirtyState(/** @type {HTMLFormElement} */(groupEl.closest('form')));
@@ -3014,9 +3085,9 @@ const { __ } = require('../i18n');
 
 		const importBtn = /** @type {HTMLElement|null} */ (dom.find('[data-lerm-backup-import]', form));
 		if (importBtn) {
-			importBtn.addEventListener('click', (e) => {
+			importBtn.addEventListener('click', async (e) => {
 				e.preventDefault();
-				if (!window.confirm(__('Importing will overwrite the current saved settings. Continue?', 'lerm-admin-config'))) return;
+				if (!await confirmDialog(__('Importing will overwrite the current saved settings. Continue?', 'lerm-admin-config'))) return;
 				const json = String(/** @type {HTMLInputElement|null} */(dom.find('[data-lerm-backup-import-input]', form))?.value ?? '');
 				pageForms(form).forEach((pageForm) => clearFieldErrors(pageForm));
 				setBusyAcrossPage(form, true, __('Resetting...', 'lerm-admin-config'));
@@ -3089,10 +3160,10 @@ const { __ } = require('../i18n');
 		});
 
 		dom.findAll('[data-lerm-reset]', form).forEach(btn => {
-			btn.addEventListener('click', (e) => {
+			btn.addEventListener('click', async (e) => {
 				e.preventDefault();
 				const scope = getData(btn, 'lerm-reset') === 'all' ? 'all' : 'section';
-				if (!window.confirm(scope === 'all' ? __('Reset every section on this page back to default values?', 'lerm-admin-config') : __('Reset the current page back to its default values?', 'lerm-admin-config'))) return;
+				if (!await confirmDialog(scope === 'all' ? __('Reset every section on this page back to default values?', 'lerm-admin-config') : __('Reset the current page back to its default values?', 'lerm-admin-config'))) return;
 				triggerEditorSave(form);
 				clearFieldErrors(form);
 				setBusy(form, true, __('Resetting...', 'lerm-admin-config'));

--- a/packages/AdminConfig/resources/admin/admin-config.js
+++ b/packages/AdminConfig/resources/admin/admin-config.js
@@ -2347,13 +2347,13 @@ let confirmDialog;
 					.then(() => {
 						button.textContent = __('Copied', 'lerm-admin-config');
 						window.setTimeout(() => {
-							button.textContent = __('Copy JSON', 'lerm-admin-config') || defaultLabel;
+							button.textContent = __('Copy JSON', 'lerm-admin-config') ;
 						}, 1400);
 					})
 					.catch(() => {
-						button.textContent = __('Unable to save the settings right now.', 'lerm-admin-config') || defaultLabel;
+						button.textContent = __('Unable to save the settings right now.', 'lerm-admin-config') ;
 						window.setTimeout(() => {
-							button.textContent = __('Copy JSON', 'lerm-admin-config') || defaultLabel;
+							button.textContent = __('Copy JSON', 'lerm-admin-config') ;
 						}, 1400);
 					});
 			});

--- a/packages/AdminConfig/resources/block-panel/index.js
+++ b/packages/AdminConfig/resources/block-panel/index.js
@@ -16,6 +16,7 @@ const {
 } = require('../core/schema-state');
 const { createDefaultControlRegistry } = require('../controls');
 const { register: registerStore, STORE_NAME } = require('../store');
+const { __, _n, sprintf } = require('../i18n');
 
 const BLOCK_PANEL_CONFIG_GLOBAL = 'lermAdminConfigBlockPanelConfigs';
 const panelInstances = new Map();
@@ -488,7 +489,7 @@ const createPanelComponent = (config, Panel, element) => {
 					className: 'lerm-admin-config-block-panel__status',
 					key: 'status',
 				},
-				status === 'ready' ? 'Ready' : status.charAt(0).toUpperCase() + status.slice(1)
+				status === 'ready' ? __('Ready', 'lerm-admin-config') : status.charAt(0).toUpperCase() + status.slice(1)
 			),
 		];
 
@@ -512,7 +513,7 @@ const createPanelComponent = (config, Panel, element) => {
 					className: 'lerm-admin-config-block-panel__meta',
 					key: 'meta',
 				},
-				`${ fieldCount(state.schema) } fields loaded`
+				sprintf(_n('%d field loaded', '%d fields loaded', fieldCount(state.schema), 'lerm-admin-config'), fieldCount(state.schema))
 			));
 		}
 
@@ -723,7 +724,7 @@ const createPanelComponent = (config, Panel, element) => {
 								onClick: saveChanges,
 								variant: 'primary',
 							},
-							status === 'saving' ? 'Saving' : 'Save'
+							status === 'saving' ? __('Saving', 'lerm-admin-config') : __('Save', 'lerm-admin-config')
 						)
 						: createElement(
 							'button',
@@ -733,7 +734,7 @@ const createPanelComponent = (config, Panel, element) => {
 								onClick: saveChanges,
 								type: 'button',
 							},
-							status === 'saving' ? 'Saving' : 'Save'
+							status === 'saving' ? __('Saving', 'lerm-admin-config') : __('Save', 'lerm-admin-config')
 						),
 					typeof Button === 'function'
 						? createElement(
@@ -744,7 +745,7 @@ const createPanelComponent = (config, Panel, element) => {
 								onClick: discardChanges,
 								variant: 'secondary',
 							},
-							'Discard'
+							__('Discard', 'lerm-admin-config')
 						)
 						: createElement(
 							'button',
@@ -754,7 +755,7 @@ const createPanelComponent = (config, Panel, element) => {
 								onClick: discardChanges,
 								type: 'button',
 							},
-							'Discard'
+							__('Discard', 'lerm-admin-config')
 						),
 					createElement(
 						'span',
@@ -763,7 +764,7 @@ const createPanelComponent = (config, Panel, element) => {
 							'data-dirty': dirty ? 'true' : 'false',
 							key: 'dirty',
 						},
-						dirty ? 'Unsaved changes' : 'Saved'
+						dirty ? __('Unsaved changes', 'lerm-admin-config') : __('Saved', 'lerm-admin-config')
 					),
 				]
 			));
@@ -823,7 +824,7 @@ const createPanelComponent = (config, Panel, element) => {
 									onClick: () => setShowDiscardDialog(false),
 									variant: 'secondary',
 								},
-								'Cancel'
+								__('Cancel', 'lerm-admin-config')
 							)
 							: null,
 						typeof Button === 'function'
@@ -835,7 +836,7 @@ const createPanelComponent = (config, Panel, element) => {
 									onClick: handleConfirmDiscard,
 									variant: 'primary',
 								},
-								'Discard'
+								__('Discard', 'lerm-admin-config')
 							)
 							: null
 					)

--- a/packages/AdminConfig/resources/block-panel/index.js
+++ b/packages/AdminConfig/resources/block-panel/index.js
@@ -516,7 +516,12 @@ const createPanelComponent = (config, Panel, element) => {
 			));
 		}
 
-		const components = asRecord((typeof window !== 'undefined' && window.wp && window.wp.components) || {});
+		let components = {};
+		try {
+			components = asRecord(require('@wordpress/components'));
+		} catch (_e) {
+			// Fallback for environments without @wordpress/components (e.g. Node.js tests).
+		}
 		const sections = orderedSections(state.schema);
 		const fieldsById = asRecord(state.schema.fields);
 		const dependencies = asRecord(state.schema.dependencies);
@@ -536,8 +541,8 @@ const createPanelComponent = (config, Panel, element) => {
 		}, []);
 
 		useEffect(() => {
-			const wpData = window.wp && window.wp.data;
-			const editorDispatch = wpData && wpData.dispatch && wpData.dispatch('core/editor');
+			const { dispatch } = require('@wordpress/data');
+			const editorDispatch = dispatch('core/editor');
 			if (dirty && editorDispatch && typeof editorDispatch.lockPostSaving === 'function') {
 				editorDispatch.lockPostSaving('lerm-admin-config-unsaved');
 			} else if (!dirty && editorDispatch && typeof editorDispatch.unlockPostSaving === 'function') {
@@ -851,11 +856,19 @@ const registerBlockEditorPanels = (configs = blockPanelConfigsFromWindow()) => {
 
 	registerStore();
 
-	const wp = window.wp || {};
-	const registerPlugin = wp.plugins && wp.plugins.registerPlugin;
-	const editorPackage = wp.editPost || wp.editor || {};
-	const Panel = editorPackage.PluginDocumentSettingPanel;
-	const element = wp.element || {};
+	let plugins, editor, element;
+	try {
+		plugins = require('@wordpress/plugins');
+	} catch (_e) { plugins = {}; }
+	try {
+		editor = require('@wordpress/editor');
+	} catch (_e) { editor = {}; }
+	try {
+		element = require('@wordpress/element');
+	} catch (_e) { element = {}; }
+
+	const { registerPlugin } = plugins;
+	const Panel = editor.PluginDocumentSettingPanel;
 
 	if (
 		typeof registerPlugin !== 'function' ||

--- a/packages/AdminConfig/resources/block-panel/index.js
+++ b/packages/AdminConfig/resources/block-panel/index.js
@@ -419,8 +419,8 @@ const renderUnavailableField = (createElement, field, controlType, status, error
 					key: 'unsupported',
 				},
 				isReadOnly
-					? `Field type "${ controlType }" is read-only in the block editor panel.`
-					: `Field type "${ controlType }" is not available in the block editor panel yet.`
+					? sprintf(__('Field type "%s" is read-only in the block editor panel.', 'lerm-admin-config'), controlType)
+					: sprintf(__('Field type "%s" is not available in the block editor panel yet.', 'lerm-admin-config'), controlType)
 			),
 			error
 				? createElement(
@@ -704,7 +704,7 @@ const createPanelComponent = (config, Panel, element) => {
 						className: 'lerm-admin-config-block-panel__save-notice',
 						key: 'save-notice',
 					},
-					'Save AdminConfig changes before updating the post — they are stored separately.'
+					__('Save AdminConfig changes before updating the post — they are stored separately.', 'lerm-admin-config')
 				))
 			}
 			body.push(createElement(

--- a/packages/AdminConfig/resources/controls/index.js
+++ b/packages/AdminConfig/resources/controls/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 const { asRecord, asRecordArray } = require('../core/records');
+const { __, sprintf } = require('../i18n');
 
 /**
  * @typedef {(props: Record<string, unknown>) => unknown} FieldControl
@@ -303,7 +304,7 @@ const renderNestedField = (normalized, field, path, value) => {
 			},
 			[
 				createElement('strong', { key: 'label' }, label),
-				createElement('p', { key: 'message' }, `Field type "${ controlType }" is not available in this composite field yet.`),
+				createElement('p', { key: 'message' }, sprintf(__('Field type "%s" is not available in this composite field yet.', 'lerm-admin-config'), controlType)),
 				error
 					? createElement('p', {
 						className: 'lerm-admin-config-block-panel__field-error',
@@ -1879,12 +1880,12 @@ const backgroundFields = (field) => {
 
 	if (fieldFlag(field, 'background_image', true)) {
 		fields.push({
-			button_text: stringValue(field.background_image_button_text || 'Choose image'),
+			button_text: stringValue(field.background_image_button_text || __('Choose image', 'lerm-admin-config')),
 			default: backgroundDefault(field, 'background-image', {}),
 			id: 'background-image',
 			label: 'Image',
 			library: 'image',
-			remove_text: 'Remove image',
+			remove_text: __('Remove image', 'lerm-admin-config'),
 			type: 'media',
 		});
 	}
@@ -2484,7 +2485,7 @@ const GroupControl = (props) => {
 							onClick: () => removeItem(index),
 							variant: 'secondary',
 						},
-						'Remove item'
+						__('Remove item', 'lerm-admin-config')
 					),
 				].filter(Boolean)
 			)),
@@ -2494,7 +2495,7 @@ const GroupControl = (props) => {
 					onClick: addItem,
 					variant: 'secondary',
 				},
-				'Add item'
+				__('Add item', 'lerm-admin-config')
 			),
 		].filter(Boolean)
 	);
@@ -2511,8 +2512,8 @@ const UploadControlComponent = (normalized) => {
 	const url = stringValue(value);
 	const label = stringValue(field.label || field.id);
 	const description = stringValue(field.description);
-	const chooseText = stringValue(field.button_text || 'Choose file');
-	const removeText = stringValue(field.remove_text || 'Remove');
+	const chooseText = stringValue(field.button_text || __('Choose file', 'lerm-admin-config'));
+	const removeText = stringValue(field.remove_text || __('Remove', 'lerm-admin-config'));
 	const fallbackInput = createElement('input', {
 		'aria-label': label,
 		className: 'lerm-admin-config-block-panel__media-url',
@@ -2598,8 +2599,8 @@ const MediaControlComponent = (normalized) => {
 	const records = useAttachmentRecords(id > 0 ? [ id ] : [], inlineRecords);
 	const label = stringValue(field.label || field.id);
 	const description = stringValue(field.description);
-	const chooseText = stringValue(field.button_text || 'Choose image');
-	const removeText = stringValue(field.remove_text || 'Remove');
+	const chooseText = stringValue(field.button_text || __('Choose image', 'lerm-admin-config'));
+	const removeText = stringValue(field.remove_text || __('Remove', 'lerm-admin-config'));
 	const body = (open) => createElement(
 		'div',
 		{
@@ -2673,8 +2674,8 @@ const GalleryControlComponent = (normalized) => {
 	const records = useAttachmentRecords(ids, inlineRecords);
 	const label = stringValue(field.label || field.id);
 	const description = stringValue(field.description);
-	const chooseText = stringValue(field.button_text || 'Choose images');
-	const removeText = stringValue(field.remove_text || 'Clear gallery');
+	const chooseText = stringValue(field.button_text || __('Choose images', 'lerm-admin-config'));
+	const removeText = stringValue(field.remove_text || __('Clear gallery', 'lerm-admin-config'));
 	const body = (open) => createElement(
 		'div',
 		{

--- a/packages/AdminConfig/resources/store/index.js
+++ b/packages/AdminConfig/resources/store/index.js
@@ -296,7 +296,16 @@ const register = () => {
 		registerWpDataStore(store);
 		isRegistered = true;
 	} catch (_error) {
-		// Silently skip registration in environments without wp.data (e.g. Node.js tests).
+		// Silently skip registration in environments without wp.data (e.g., Node.js tests).
+		// In browser environments where wp.data exists, a failure indicates a real issue.
+		if (typeof window !== 'undefined' && window.wp && window.wp.data) {
+			console.warn(
+				'[lerm/admin-config] Failed to register wp.data store. ' +
+				'Another plugin may have registered a conflicting store name, ' +
+				'or the store configuration is invalid.',
+				_error
+			);
+		}
 	}
 };
 

--- a/packages/AdminConfig/resources/store/index.js
+++ b/packages/AdminConfig/resources/store/index.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const { createReduxStore, registerStore } = require('@wordpress/data');
+const { createReduxStore, register: registerWpDataStore } = require('@wordpress/data');
 
 const STORE_NAME = 'lerm/admin-config';
 
@@ -293,7 +293,7 @@ const register = () => {
 	}
 
 	try {
-		registerStore(store);
+		registerWpDataStore(store);
 		isRegistered = true;
 	} catch (_error) {
 		// Silently skip registration in environments without wp.data (e.g. Node.js tests).

--- a/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
+++ b/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
@@ -221,6 +221,12 @@ final class OptionsPage {
 			true
 		);
 
+		wp_set_script_translations(
+			$js_handle,
+			'lerm-admin-config',
+			dirname( __DIR__, 3 ) . '/languages/'
+		);
+
 		wp_localize_script(
 			$js_handle,
 			$this->js_global,

--- a/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
+++ b/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
@@ -224,7 +224,7 @@ final class OptionsPage {
 		wp_set_script_translations(
 			$js_handle,
 			'lerm-admin-config',
-			dirname( __DIR__, 3 ) . '/languages/'
+			dirname( PackageAssets::directory() ) . '/languages/'
 		);
 
 		wp_localize_script(

--- a/packages/AdminConfig/src/Framework/Support/I18nStrings.php
+++ b/packages/AdminConfig/src/Framework/Support/I18nStrings.php
@@ -1,6 +1,11 @@
 <?php
 /**
- * Localized strings used by AdminConfig JavaScript runtimes.
+ * Admin page config passed to the AdminConfig JavaScript runtime.
+ *
+ * i18n strings are no longer passed via wp_localize_script — they are handled
+ * client-side via @wordpress/i18n __() calls and loaded by
+ * wp_set_script_translations(). See resources/i18n/index.js and
+ * OptionsPage::enqueue_assets().
  *
  * @package Lerm\AdminConfig
  */
@@ -16,58 +21,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class I18nStrings {
 
 	/**
+	 * Returns runtime config for the admin page JS.
+	 *
+	 * Only returns non-translatable config data (URLs, nonces, editor settings).
+	 * Translatable strings are handled client-side via @wordpress/i18n.
+	 *
 	 * @param mixed $code_editor_settings Code editor settings returned by wp_enqueue_code_editor().
 	 * @return array<string, mixed>
 	 */
 	public static function for_admin_page( $code_editor_settings ): array {
 		return array(
-			'restUrl'             => rest_url( 'lerm-admin-config/v1/' ),
-			'restNonce'           => wp_create_nonce( 'wp_rest' ),
-			'codeEditor'          => $code_editor_settings,
-			'selectMedia'         => __( 'Choose image', 'lerm-admin-config' ),
-			'useMedia'            => __( 'Use this image', 'lerm-admin-config' ),
-			'selectFile'          => __( 'Choose file', 'lerm-admin-config' ),
-			'useFile'             => __( 'Use this file', 'lerm-admin-config' ),
-			'selectImages'        => __( 'Choose images', 'lerm-admin-config' ),
-			'useImages'           => __( 'Use these images', 'lerm-admin-config' ),
-			'removeMedia'         => __( 'Remove image', 'lerm-admin-config' ),
-			'clearGallery'        => __( 'Clear gallery', 'lerm-admin-config' ),
-			'noMedia'             => __( 'No image selected.', 'lerm-admin-config' ),
-			'noGallery'           => __( 'No gallery images selected.', 'lerm-admin-config' ),
-			'searchPrompt'        => __( 'Start typing to search.', 'lerm-admin-config' ),
-			'searchMinPrompt'     => __( 'Type more characters to search.', 'lerm-admin-config' ),
-			'loadingResults'      => __( 'Loading results...', 'lerm-admin-config' ),
-			'noResults'           => __( 'No matching results found.', 'lerm-admin-config' ),
-			'loadMoreResults'     => __( 'Load more', 'lerm-admin-config' ),
-			'clearSelection'      => __( 'Clear selection', 'lerm-admin-config' ),
-			'removeSelection'     => __( 'Remove selection', 'lerm-admin-config' ),
-			'saving'              => __( 'Saving...', 'lerm-admin-config' ),
-			'saveSuccess'         => __( 'Settings saved.', 'lerm-admin-config' ),
-			'saveError'           => __( 'Unable to save the settings right now.', 'lerm-admin-config' ),
-			'resetting'           => __( 'Resetting...', 'lerm-admin-config' ),
-			'resetSectionSuccess' => __( 'The current page has been reset to defaults.', 'lerm-admin-config' ),
-			'resetAllSuccess'     => __( 'All sections have been reset to defaults.', 'lerm-admin-config' ),
-			'resetError'          => __( 'Unable to reset the settings right now.', 'lerm-admin-config' ),
-			'confirmResetSection' => __( 'Reset the current page back to its default values?', 'lerm-admin-config' ),
-			'confirmResetAll'     => __( 'Reset every section on this page back to default values?', 'lerm-admin-config' ),
-			'confirmNavigate'     => __( 'You have unsaved changes in this tab. Leave without saving?', 'lerm-admin-config' ),
-			'confirmLeave'        => __( 'You have unsaved changes that have not been saved yet.', 'lerm-admin-config' ),
-			'statusReady'         => __( 'Synced', 'lerm-admin-config' ),
-			'statusDirty'         => __( 'Unsaved changes', 'lerm-admin-config' ),
-			'statusSaving'        => __( 'Saving...', 'lerm-admin-config' ),
-			'statusResetting'     => __( 'Resetting...', 'lerm-admin-config' ),
-			'statusSaved'         => __( 'Saved', 'lerm-admin-config' ),
-			'statusError'         => __( 'Error', 'lerm-admin-config' ),
-			'groupAdd'            => __( 'Add item', 'lerm-admin-config' ),
-			'groupRemove'         => __( 'Remove', 'lerm-admin-config' ),
-			'groupEmpty'          => __( 'No items added yet.', 'lerm-admin-config' ),
-			'confirmRemoveItem'   => __( 'Remove this item?', 'lerm-admin-config' ),
-			'exportSuccess'       => __( 'Current settings snapshot generated.', 'lerm-admin-config' ),
-			'importSuccess'       => __( 'Settings imported successfully.', 'lerm-admin-config' ),
-			'importError'         => __( 'Unable to import the provided settings JSON.', 'lerm-admin-config' ),
-			'confirmImport'       => __( 'Importing will overwrite the current saved settings. Continue?', 'lerm-admin-config' ),
-			'debugCopy'           => __( 'Copy JSON', 'lerm-admin-config' ),
-			'debugCopied'         => __( 'Copied', 'lerm-admin-config' ),
+			'restUrl'    => rest_url( 'lerm-admin-config/v1/' ),
+			'restNonce'  => wp_create_nonce( 'wp_rest' ),
+			'codeEditor' => $code_editor_settings,
 		);
 	}
 }

--- a/packages/AdminConfig/src/WordPress/Containers/BlockEditorPanelContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/BlockEditorPanelContainer.php
@@ -54,7 +54,7 @@ final class BlockEditorPanelContainer implements Container {
 		$this->hooks_registered = true;
 	}
 
-	private function containerTypeForBlockPanel(): string {
+	private function container_type_for_block_panel(): string {
 		return 'block_editor_panel';
 	}
 }

--- a/packages/AdminConfig/src/WordPress/Containers/BlockEditorPanelContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/BlockEditorPanelContainer.php
@@ -16,16 +16,16 @@ namespace Lerm\AdminConfig\WordPress\Containers;
 
 use Lerm\AdminConfig\Compiler\CompiledSchema;
 use Lerm\AdminConfig\Contracts\Container;
-use Lerm\AdminConfig\Framework\Contracts\AssetPathResolver;
 use Lerm\AdminConfig\Framework\Framework;
-use Lerm\AdminConfig\Framework\Support\PackageAssets;
-use Lerm\AdminConfig\Framework\Support\ScriptAssetMetadata;
+use Lerm\AdminConfig\WordPress\Support\HasBlockEditorPanel;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 final class BlockEditorPanelContainer implements Container {
+
+	use HasBlockEditorPanel;
 
 	/**
 	 * @var array<string, CompiledSchema>
@@ -54,204 +54,7 @@ final class BlockEditorPanelContainer implements Container {
 		$this->hooks_registered = true;
 	}
 
-	public function enqueue_block_editor_assets(): void {
-		$editor_context = $this->current_editor_context();
-
-		if ( empty( $editor_context['post_id'] ) || '' === $editor_context['post_type'] ) {
-			return;
-		}
-
-		$schemas = $this->block_editor_schemas( $editor_context['post_type'], $editor_context['post_id'] );
-
-		if ( empty( $schemas ) ) {
-			return;
-		}
-
-		wp_enqueue_media();
-
-		$script = $this->block_panel_script_asset();
-		$handle = 'lerm-admin-config-block-panel';
-
-		wp_enqueue_script(
-			$handle,
-			$this->asset_url( $script['file'] ),
-			$script['dependencies'],
-			$script['version'],
-			true
-		);
-
-		wp_enqueue_style(
-			$handle,
-			$this->asset_url( 'block-panel.css' ),
-			array( 'wp-components' ),
-			$this->asset_version()
-		);
-
-		wp_set_script_translations(
-			$handle,
-			'lerm-admin-config',
-			dirname( __DIR__, 3 ) . '/languages/'
-		);
-
-		$payload = wp_json_encode(
-			array(
-				'restUrl'   => rest_url( 'lerm-admin-config/v1/' ),
-				'restNonce' => wp_create_nonce( 'wp_rest' ),
-				'schemas'   => $schemas,
-			)
-		);
-
-		if ( false === $payload ) {
-			return;
-		}
-
-		wp_add_inline_script(
-			$handle,
-			'window.lermAdminConfigBlockPanelConfigs = window.lermAdminConfigBlockPanelConfigs || []; window.lermAdminConfigBlockPanelConfigs.push(' . $payload . ');',
-			'before'
-		);
-	}
-
-	/**
-	 * @return array{post_id: int, post_type: string}
-	 */
-	private function current_editor_context(): array {
-		$post_id   = 0;
-		$post_type = '';
-
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-
-		if ( is_object( $screen ) ) {
-			$screen_vars      = get_object_vars( $screen );
-			$screen_post_type = $screen_vars['post_type'] ?? '';
-
-			if ( is_scalar( $screen_post_type ) ) {
-				$post_type = sanitize_key( (string) $screen_post_type );
-			}
-		}
-
-		if ( isset( $_GET['post'] ) ) {
-			$post_id = absint( wp_unslash( $_GET['post'] ) );
-		}
-
-		global $post;
-
-		if ( 0 === $post_id && is_object( $post ) && isset( $post->ID ) ) {
-			$post_id = absint( $post->ID );
-		}
-
-		if ( '' === $post_type && is_object( $post ) && isset( $post->post_type ) && is_scalar( $post->post_type ) ) {
-			$post_type = sanitize_key( (string) $post->post_type );
-		}
-
-		if ( '' === $post_type && $post_id > 0 && function_exists( 'get_post_type' ) ) {
-			$resolved_post_type = get_post_type( $post_id );
-
-			if ( is_scalar( $resolved_post_type ) ) {
-				$post_type = sanitize_key( (string) $resolved_post_type );
-			}
-		}
-
-		return array(
-			'post_id'   => $post_id,
-			'post_type' => $post_type,
-		);
-	}
-
-	/**
-	 * @return array<int, array<string, mixed>>
-	 */
-	private function block_editor_schemas( string $post_type, int $post_id ): array {
-		$schemas = array();
-
-		foreach ( $this->schemas as $schema ) {
-			$container = $schema->container();
-
-			if ( ! in_array( $post_type, $this->normalize_post_types( $container['post_types'] ?? array() ), true ) ) {
-				continue;
-			}
-
-			$capability = (string) ( $container['capability'] ?? 'edit_post' );
-
-			if ( ! current_user_can( $capability, $post_id ) ) {
-				continue;
-			}
-
-			$schemas[] = array(
-				'schemaId'      => $schema->id(),
-				'title'         => (string) ( $container['title'] ?? $schema->definition()['title'] ?? __( 'Settings', 'lerm-admin-config' ) ),
-				'containerType' => 'block_editor_panel',
-				'postType'      => $post_type,
-				'context'       => array(
-					'post_id' => $post_id,
-				),
-			);
-		}
-
-		return $schemas;
-	}
-
-	/**
-	 * @return array{file: string, dependencies: array<int, string>, version: string}
-	 */
-	private function block_panel_script_asset(): array {
-		return ScriptAssetMetadata::resolve(
-			'block-panel',
-			'build/block-panel.js',
-			array(
-				'wp-api-fetch',
-				'wp-block-editor',
-				'wp-components',
-				'wp-edit-post',
-				'wp-element',
-				'wp-plugins',
-			),
-			$this->asset_version(),
-			function ( string $asset ): string {
-				return $this->asset_path( $asset );
-			}
-		);
-	}
-
-	private function asset_url( string $asset ): string {
-		return $this->framework->asset_resolver()->url( $asset );
-	}
-
-	private function asset_path( string $asset ): string {
-		$resolver = $this->framework->asset_resolver();
-
-		if ( $resolver instanceof AssetPathResolver ) {
-			return $resolver->path( $asset );
-		}
-
-		return PackageAssets::path( $asset );
-	}
-
-	private function asset_version(): string {
-		return $this->framework->asset_resolver()->version();
-	}
-
-	/**
-	 * @param mixed $post_types
-	 * @return array<int, string>
-	 */
-	private function normalize_post_types( $post_types ): array {
-		$normalized = array();
-
-		foreach ( is_array( $post_types ) ? $post_types : array( $post_types ) as $post_type ) {
-			if ( ! is_scalar( $post_type ) ) {
-				continue;
-			}
-
-			$value = sanitize_key( (string) $post_type );
-
-			if ( '' === $value ) {
-				continue;
-			}
-
-			$normalized[] = $value;
-		}
-
-		return array_values( array_unique( $normalized ) );
+	private function containerTypeForBlockPanel(): string {
+		return 'block_editor_panel';
 	}
 }

--- a/packages/AdminConfig/src/WordPress/Containers/BlockEditorPanelContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/BlockEditorPanelContainer.php
@@ -16,7 +16,6 @@ namespace Lerm\AdminConfig\WordPress\Containers;
 
 use Lerm\AdminConfig\Compiler\CompiledSchema;
 use Lerm\AdminConfig\Contracts\Container;
-use Lerm\AdminConfig\Stores\StoreResolver;
 use Lerm\AdminConfig\Framework\Contracts\AssetPathResolver;
 use Lerm\AdminConfig\Framework\Framework;
 use Lerm\AdminConfig\Framework\Support\PackageAssets;
@@ -36,8 +35,7 @@ final class BlockEditorPanelContainer implements Container {
 	private bool $hooks_registered = false;
 
 	public function __construct(
-		private Framework $framework,
-		private StoreResolver $stores
+		private Framework $framework
 	) {
 	}
 

--- a/packages/AdminConfig/src/WordPress/Containers/BlockEditorPanelContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/BlockEditorPanelContainer.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * WordPress block editor panel container for admin-config schemas.
+ *
+ * Mounted schemas appear as side-panel controls in the Gutenberg editor
+ * via the shared block-panel JavaScript bundle. Unlike MetaboxContainer,
+ * this container only activates when the block editor is in use — it never
+ * renders classic meta boxes.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\WordPress\Containers;
+
+use Lerm\AdminConfig\Compiler\CompiledSchema;
+use Lerm\AdminConfig\Contracts\Container;
+use Lerm\AdminConfig\Stores\StoreResolver;
+use Lerm\AdminConfig\Framework\Contracts\AssetPathResolver;
+use Lerm\AdminConfig\Framework\Framework;
+use Lerm\AdminConfig\Framework\Support\PackageAssets;
+use Lerm\AdminConfig\Framework\Support\ScriptAssetMetadata;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class BlockEditorPanelContainer implements Container {
+
+	/**
+	 * @var array<string, CompiledSchema>
+	 */
+	private array $schemas = array();
+
+	private bool $hooks_registered = false;
+
+	public function __construct(
+		private Framework $framework,
+		private StoreResolver $stores
+	) {
+	}
+
+	public function type(): string {
+		return 'block_editor_panel';
+	}
+
+	public function mount( CompiledSchema $schema ): void {
+		$this->schemas[ $schema->id() ] = $schema;
+
+		if ( $this->hooks_registered ) {
+			return;
+		}
+
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
+		$this->hooks_registered = true;
+	}
+
+	public function enqueue_block_editor_assets(): void {
+		$editor_context = $this->current_editor_context();
+
+		if ( empty( $editor_context['post_id'] ) || '' === $editor_context['post_type'] ) {
+			return;
+		}
+
+		$schemas = $this->block_editor_schemas( $editor_context['post_type'], $editor_context['post_id'] );
+
+		if ( empty( $schemas ) ) {
+			return;
+		}
+
+		wp_enqueue_media();
+
+		$script = $this->block_panel_script_asset();
+		$handle = 'lerm-admin-config-block-panel';
+
+		wp_enqueue_script(
+			$handle,
+			$this->asset_url( $script['file'] ),
+			$script['dependencies'],
+			$script['version'],
+			true
+		);
+
+		wp_enqueue_style(
+			$handle,
+			$this->asset_url( 'block-panel.css' ),
+			array( 'wp-components' ),
+			$this->asset_version()
+		);
+
+		$payload = wp_json_encode(
+			array(
+				'restUrl'   => rest_url( 'lerm-admin-config/v1/' ),
+				'restNonce' => wp_create_nonce( 'wp_rest' ),
+				'schemas'   => $schemas,
+			)
+		);
+
+		if ( false === $payload ) {
+			return;
+		}
+
+		wp_add_inline_script(
+			$handle,
+			'window.lermAdminConfigBlockPanelConfigs = window.lermAdminConfigBlockPanelConfigs || []; window.lermAdminConfigBlockPanelConfigs.push(' . $payload . ');',
+			'before'
+		);
+	}
+
+	/**
+	 * @return array{post_id: int, post_type: string}
+	 */
+	private function current_editor_context(): array {
+		$post_id   = 0;
+		$post_type = '';
+
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( is_object( $screen ) ) {
+			$screen_vars      = get_object_vars( $screen );
+			$screen_post_type = $screen_vars['post_type'] ?? '';
+
+			if ( is_scalar( $screen_post_type ) ) {
+				$post_type = sanitize_key( (string) $screen_post_type );
+			}
+		}
+
+		if ( isset( $_GET['post'] ) ) {
+			$post_id = absint( wp_unslash( $_GET['post'] ) );
+		}
+
+		global $post;
+
+		if ( 0 === $post_id && is_object( $post ) && isset( $post->ID ) ) {
+			$post_id = absint( $post->ID );
+		}
+
+		if ( '' === $post_type && is_object( $post ) && isset( $post->post_type ) && is_scalar( $post->post_type ) ) {
+			$post_type = sanitize_key( (string) $post->post_type );
+		}
+
+		if ( '' === $post_type && $post_id > 0 && function_exists( 'get_post_type' ) ) {
+			$resolved_post_type = get_post_type( $post_id );
+
+			if ( is_scalar( $resolved_post_type ) ) {
+				$post_type = sanitize_key( (string) $resolved_post_type );
+			}
+		}
+
+		return array(
+			'post_id'   => $post_id,
+			'post_type' => $post_type,
+		);
+	}
+
+	/**
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function block_editor_schemas( string $post_type, int $post_id ): array {
+		$schemas = array();
+
+		foreach ( $this->schemas as $schema ) {
+			$container = $schema->container();
+
+			if ( ! in_array( $post_type, $this->normalize_post_types( $container['post_types'] ?? array() ), true ) ) {
+				continue;
+			}
+
+			$capability = (string) ( $container['capability'] ?? 'edit_post' );
+
+			if ( ! current_user_can( $capability, $post_id ) ) {
+				continue;
+			}
+
+			$schemas[] = array(
+				'schemaId'      => $schema->id(),
+				'title'         => (string) ( $container['title'] ?? $schema->definition()['title'] ?? __( 'Settings', 'lerm-admin-config' ) ),
+				'containerType' => 'block_editor_panel',
+				'postType'      => $post_type,
+				'context'       => array(
+					'post_id' => $post_id,
+				),
+			);
+		}
+
+		return $schemas;
+	}
+
+	/**
+	 * @return array{file: string, dependencies: array<int, string>, version: string}
+	 */
+	private function block_panel_script_asset(): array {
+		return ScriptAssetMetadata::resolve(
+			'block-panel',
+			'build/block-panel.js',
+			array(
+				'wp-api-fetch',
+				'wp-block-editor',
+				'wp-components',
+				'wp-edit-post',
+				'wp-element',
+				'wp-plugins',
+			),
+			$this->asset_version(),
+			function ( string $asset ): string {
+				return $this->asset_path( $asset );
+			}
+		);
+	}
+
+	private function asset_url( string $asset ): string {
+		return $this->framework->asset_resolver()->url( $asset );
+	}
+
+	private function asset_path( string $asset ): string {
+		$resolver = $this->framework->asset_resolver();
+
+		if ( $resolver instanceof AssetPathResolver ) {
+			return $resolver->path( $asset );
+		}
+
+		return PackageAssets::path( $asset );
+	}
+
+	private function asset_version(): string {
+		return $this->framework->asset_resolver()->version();
+	}
+
+	/**
+	 * @param mixed $post_types
+	 * @return array<int, string>
+	 */
+	private function normalize_post_types( $post_types ): array {
+		$normalized = array();
+
+		foreach ( is_array( $post_types ) ? $post_types : array( $post_types ) as $post_type ) {
+			if ( ! is_scalar( $post_type ) ) {
+				continue;
+			}
+
+			$value = sanitize_key( (string) $post_type );
+
+			if ( '' === $value ) {
+				continue;
+			}
+
+			$normalized[] = $value;
+		}
+
+		return array_values( array_unique( $normalized ) );
+	}
+}

--- a/packages/AdminConfig/src/WordPress/Containers/BlockEditorPanelContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/BlockEditorPanelContainer.php
@@ -87,6 +87,12 @@ final class BlockEditorPanelContainer implements Container {
 			$this->asset_version()
 		);
 
+		wp_set_script_translations(
+			$handle,
+			'lerm-admin-config',
+			dirname( __DIR__, 3 ) . '/languages/'
+		);
+
 		$payload = wp_json_encode(
 			array(
 				'restUrl'   => rest_url( 'lerm-admin-config/v1/' ),

--- a/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
@@ -42,7 +42,7 @@ final class MetaboxContainer implements Container {
 	) {
 	}
 
-	private function containerTypeForBlockPanel(): string {
+	private function container_type_for_block_panel(): string {
 		return 'metabox';
 	}
 

--- a/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
@@ -16,9 +16,8 @@ use Lerm\AdminConfig\Framework\Contracts\AssetPathResolver;
 use Lerm\AdminConfig\Framework\Admin\OptionsPage;
 use Lerm\AdminConfig\Framework\Framework;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
-use Lerm\AdminConfig\Framework\Support\PackageAssets;
 use Lerm\AdminConfig\Framework\Support\PageSchema;
-use Lerm\AdminConfig\Framework\Support\ScriptAssetMetadata;
+use Lerm\AdminConfig\WordPress\Support\HasBlockEditorPanel;
 use Lerm\AdminConfig\WordPress\Support\ContainerSaveSupport;
 use Lerm\AdminConfig\WordPress\Support\ValidationFlash;
 
@@ -27,6 +26,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 final class MetaboxContainer implements Container {
+
+	use HasBlockEditorPanel;
 
 	/**
 	 * @var array<string, CompiledSchema>
@@ -39,6 +40,10 @@ final class MetaboxContainer implements Container {
 		private Framework $framework,
 		private StoreResolver $stores
 	) {
+	}
+
+	private function containerTypeForBlockPanel(): string {
+		return 'metabox';
 	}
 
 	public function type(): string {
@@ -56,58 +61,6 @@ final class MetaboxContainer implements Container {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		add_action( 'save_post', array( $this, 'save_post' ), 10, 2 );
 		$this->hooks_registered = true;
-	}
-
-	public function enqueue_block_editor_assets(): void {
-		$editor_context = $this->current_editor_context();
-
-		if ( empty( $editor_context['post_id'] ) || '' === $editor_context['post_type'] ) {
-			return;
-		}
-
-		$schemas = $this->block_editor_schemas( $editor_context['post_type'], $editor_context['post_id'] );
-
-		if ( empty( $schemas ) ) {
-			return;
-		}
-
-		wp_enqueue_media();
-
-		$script = $this->block_panel_script_asset();
-		$handle = 'lerm-admin-config-block-panel';
-
-		wp_enqueue_script(
-			$handle,
-			$this->asset_url( $script['file'] ),
-			$script['dependencies'],
-			$script['version'],
-			true
-		);
-
-		wp_enqueue_style(
-			$handle,
-			$this->asset_url( 'block-panel.css' ),
-			array( 'wp-components' ),
-			$this->asset_version()
-		);
-
-		$payload = wp_json_encode(
-			array(
-				'restUrl'   => rest_url( 'lerm-admin-config/v1/' ),
-				'restNonce' => wp_create_nonce( 'wp_rest' ),
-				'schemas'   => $schemas,
-			)
-		);
-
-		if ( false === $payload ) {
-			return;
-		}
-
-		wp_add_inline_script(
-			$handle,
-			'window.lermAdminConfigBlockPanelConfigs = window.lermAdminConfigBlockPanelConfigs || []; window.lermAdminConfigBlockPanelConfigs.push(' . $payload . ');',
-			'before'
-		);
 	}
 
 	public function register_meta_boxes( string $post_type, $post = null ): void {
@@ -242,125 +195,6 @@ final class MetaboxContainer implements Container {
 
 	private function nonce_action( CompiledSchema $schema ): string {
 		return 'lerm_admin_config_metabox_' . $schema->id();
-	}
-
-	/**
-	 * @return array{post_id: int, post_type: string}
-	 */
-	private function current_editor_context(): array {
-		$post_id   = 0;
-		$post_type = '';
-
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-
-		if ( is_object( $screen ) ) {
-			$screen_vars      = get_object_vars( $screen );
-			$screen_post_type = $screen_vars['post_type'] ?? '';
-
-			if ( is_scalar( $screen_post_type ) ) {
-				$post_type = sanitize_key( (string) $screen_post_type );
-			}
-		}
-
-		if ( isset( $_GET['post'] ) ) {
-			$post_id = absint( wp_unslash( $_GET['post'] ) );
-		}
-
-		global $post;
-
-		if ( 0 === $post_id && is_object( $post ) && isset( $post->ID ) ) {
-			$post_id = absint( $post->ID );
-		}
-
-		if ( '' === $post_type && is_object( $post ) && isset( $post->post_type ) && is_scalar( $post->post_type ) ) {
-			$post_type = sanitize_key( (string) $post->post_type );
-		}
-
-		if ( '' === $post_type && $post_id > 0 && function_exists( 'get_post_type' ) ) {
-			$resolved_post_type = get_post_type( $post_id );
-
-			if ( is_scalar( $resolved_post_type ) ) {
-				$post_type = sanitize_key( (string) $resolved_post_type );
-			}
-		}
-
-		return array(
-			'post_id'   => $post_id,
-			'post_type' => $post_type,
-		);
-	}
-
-	/**
-	 * @return array<int, array<string, mixed>>
-	 */
-	private function block_editor_schemas( string $post_type, int $post_id ): array {
-		$schemas = array();
-
-		foreach ( $this->schemas as $schema ) {
-			$container = $schema->container();
-
-			if ( ! in_array( $post_type, $this->normalize_post_types( $container['post_types'] ?? array() ), true ) ) {
-				continue;
-			}
-
-			$capability = (string) ( $container['capability'] ?? 'edit_post' );
-
-			if ( ! current_user_can( $capability, $post_id ) ) {
-				continue;
-			}
-
-			$schemas[] = array(
-				'schemaId'      => $schema->id(),
-				'title'         => (string) ( $container['title'] ?? $schema->definition()['title'] ?? __( 'Settings', 'lerm-admin-config' ) ),
-				'containerType' => 'metabox',
-				'postType'      => $post_type,
-				'context'       => array(
-					'post_id' => $post_id,
-				),
-			);
-		}
-
-		return $schemas;
-	}
-
-	/**
-	 * @return array{file: string, dependencies: array<int, string>, version: string}
-	 */
-	private function block_panel_script_asset(): array {
-		return ScriptAssetMetadata::resolve(
-			'block-panel',
-			'build/block-panel.js',
-			array(
-				'wp-api-fetch',
-				'wp-block-editor',
-				'wp-components',
-				'wp-edit-post',
-				'wp-element',
-				'wp-plugins',
-			),
-			$this->asset_version(),
-			function ( string $asset ): string {
-				return $this->asset_path( $asset );
-			}
-		);
-	}
-
-	private function asset_url( string $asset ): string {
-		return $this->framework->asset_resolver()->url( $asset );
-	}
-
-	private function asset_path( string $asset ): string {
-		$resolver = $this->framework->asset_resolver();
-
-		if ( $resolver instanceof AssetPathResolver ) {
-			return $resolver->path( $asset );
-		}
-
-		return PackageAssets::path( $asset );
-	}
-
-	private function asset_version(): string {
-		return $this->framework->asset_resolver()->version();
 	}
 
 	/**

--- a/packages/AdminConfig/src/WordPress/Runtime.php
+++ b/packages/AdminConfig/src/WordPress/Runtime.php
@@ -71,7 +71,7 @@ final class Runtime {
 		$this->containers->register( new OptionsPageContainer( $this->framework, $this->stores ) );
 		$this->containers->register( new NetworkOptionsPageContainer( $this->framework, $this->stores ) );
 		$this->containers->register( new MetaboxContainer( $this->framework, $this->stores ) );
-		$this->containers->register( new BlockEditorPanelContainer( $this->framework, $this->stores ) );
+		$this->containers->register( new BlockEditorPanelContainer( $this->framework ) );
 		$this->containers->register( new CommentContainer( $this->framework, $this->stores ) );
 		$this->containers->register( new ProfileContainer( $this->framework, $this->stores ) );
 		$this->containers->register( new TaxonomyContainer( $this->framework, $this->stores ) );

--- a/packages/AdminConfig/src/WordPress/Runtime.php
+++ b/packages/AdminConfig/src/WordPress/Runtime.php
@@ -20,6 +20,7 @@ use Lerm\AdminConfig\Registry\SchemaRegistry;
 use Lerm\AdminConfig\Rest\RestEndpoints;
 use Lerm\AdminConfig\Stores\MissingStoreContextException;
 use Lerm\AdminConfig\Stores\StoreResolver;
+use Lerm\AdminConfig\WordPress\Containers\BlockEditorPanelContainer;
 use Lerm\AdminConfig\WordPress\Containers\CommentContainer;
 use Lerm\AdminConfig\WordPress\Containers\MetaboxContainer;
 use Lerm\AdminConfig\WordPress\Containers\NetworkOptionsPageContainer;
@@ -70,6 +71,7 @@ final class Runtime {
 		$this->containers->register( new OptionsPageContainer( $this->framework, $this->stores ) );
 		$this->containers->register( new NetworkOptionsPageContainer( $this->framework, $this->stores ) );
 		$this->containers->register( new MetaboxContainer( $this->framework, $this->stores ) );
+		$this->containers->register( new BlockEditorPanelContainer( $this->framework, $this->stores ) );
 		$this->containers->register( new CommentContainer( $this->framework, $this->stores ) );
 		$this->containers->register( new ProfileContainer( $this->framework, $this->stores ) );
 		$this->containers->register( new TaxonomyContainer( $this->framework, $this->stores ) );
@@ -415,6 +417,7 @@ final class Runtime {
 				return current_user_can( (string) ( $menu['capability'] ?? $container['capability'] ?? 'manage_network_options' ) );
 
 			case 'metabox':
+			case 'block_editor_panel':
 				if ( ! empty( $context['post_id'] ) && ! empty( $container['capability'] ) ) {
 					return current_user_can( (string) $container['capability'], $context['post_id'] );
 				}

--- a/packages/AdminConfig/src/WordPress/Support/HasBlockEditorPanel.php
+++ b/packages/AdminConfig/src/WordPress/Support/HasBlockEditorPanel.php
@@ -67,7 +67,7 @@ trait HasBlockEditorPanel {
 		wp_set_script_translations(
 			$handle,
 			'lerm-admin-config',
-			dirname( __DIR__, 3 ) . '/languages/'
+			dirname( PackageAssets::directory() ) . '/languages/'
 		);
 
 		$payload = wp_json_encode(

--- a/packages/AdminConfig/src/WordPress/Support/HasBlockEditorPanel.php
+++ b/packages/AdminConfig/src/WordPress/Support/HasBlockEditorPanel.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Shared block editor panel enqueue logic for admin-config containers.
+ *
+ * Consuming classes MUST declare:
+ *   private array $schemas     — compiled schemas keyed by schema ID
+ *   private Framework $framework — for asset resolution
+ *
+ * And MUST implement:
+ *   private function containerTypeForBlockPanel(): string
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\WordPress\Support;
+
+use Lerm\AdminConfig\Framework\Contracts\AssetPathResolver;
+use Lerm\AdminConfig\Framework\Support\PackageAssets;
+use Lerm\AdminConfig\Framework\Support\ScriptAssetMetadata;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+trait HasBlockEditorPanel {
+
+	/**
+	 * Enqueue block editor panel assets.
+	 *
+	 * Hook this as: add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
+	 */
+	public function enqueue_block_editor_assets(): void {
+		$ctx = $this->resolveEditorContext();
+
+		if ( empty( $ctx['post_id'] ) || '' === $ctx['post_type'] ) {
+			return;
+		}
+
+		$panel_schemas = $this->collectPanelSchemas( $ctx['post_type'], $ctx['post_id'] );
+
+		if ( empty( $panel_schemas ) ) {
+			return;
+		}
+
+		wp_enqueue_media();
+
+		$script = $this->resolvePanelScriptAsset();
+		$handle = 'lerm-admin-config-block-panel';
+
+		wp_enqueue_script(
+			$handle,
+			$this->panelAssetUrl( $script['file'] ),
+			$script['dependencies'],
+			$script['version'],
+			true
+		);
+
+		wp_enqueue_style(
+			$handle,
+			$this->panelAssetUrl( 'block-panel.css' ),
+			array( 'wp-components' ),
+			$this->panelAssetVersion()
+		);
+
+		wp_set_script_translations(
+			$handle,
+			'lerm-admin-config',
+			dirname( __DIR__, 3 ) . '/languages/'
+		);
+
+		$payload = wp_json_encode(
+			array(
+				'restUrl'   => rest_url( 'lerm-admin-config/v1/' ),
+				'restNonce' => wp_create_nonce( 'wp_rest' ),
+				'schemas'   => $panel_schemas,
+			)
+		);
+
+		if ( false === $payload ) {
+			return;
+		}
+
+		wp_add_inline_script(
+			$handle,
+			'window.lermAdminConfigBlockPanelConfigs = window.lermAdminConfigBlockPanelConfigs || []; window.lermAdminConfigBlockPanelConfigs.push(' . $payload . ');',
+			'before'
+		);
+	}
+
+	/**
+	 * @return array{post_id: int, post_type: string}
+	 */
+	private function resolveEditorContext(): array {
+		$post_id   = 0;
+		$post_type = '';
+
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( is_object( $screen ) ) {
+			$screen_vars      = get_object_vars( $screen );
+			$screen_post_type = $screen_vars['post_type'] ?? '';
+
+			if ( is_scalar( $screen_post_type ) ) {
+				$post_type = sanitize_key( (string) $screen_post_type );
+			}
+		}
+
+		if ( isset( $_GET['post'] ) ) {
+			$post_id = absint( wp_unslash( $_GET['post'] ) );
+		}
+
+		global $post;
+
+		if ( 0 === $post_id && is_object( $post ) && isset( $post->ID ) ) {
+			$post_id = absint( $post->ID );
+		}
+
+		if ( '' === $post_type && is_object( $post ) && isset( $post->post_type ) && is_scalar( $post->post_type ) ) {
+			$post_type = sanitize_key( (string) $post->post_type );
+		}
+
+		if ( '' === $post_type && $post_id > 0 && function_exists( 'get_post_type' ) ) {
+			$resolved_post_type = get_post_type( $post_id );
+
+			if ( is_scalar( $resolved_post_type ) ) {
+				$post_type = sanitize_key( (string) $resolved_post_type );
+			}
+		}
+
+		return array(
+			'post_id'   => $post_id,
+			'post_type' => $post_type,
+		);
+	}
+
+	/**
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function collectPanelSchemas( string $post_type, int $post_id ): array {
+		$schemas = array();
+
+		foreach ( $this->schemas as $schema ) {
+			$container = $schema->container();
+
+			if ( ! in_array( $post_type, $this->normalizePostTypes( $container['post_types'] ?? array() ), true ) ) {
+				continue;
+			}
+
+			$capability = (string) ( $container['capability'] ?? 'edit_post' );
+
+			if ( ! current_user_can( $capability, $post_id ) ) {
+				continue;
+			}
+
+			$schemas[] = array(
+				'schemaId'      => $schema->id(),
+				'title'         => (string) ( $container['title'] ?? $schema->definition()['title'] ?? __( 'Settings', 'lerm-admin-config' ) ),
+				'containerType' => $this->containerTypeForBlockPanel(),
+				'postType'      => $post_type,
+				'context'       => array(
+					'post_id' => $post_id,
+				),
+			);
+		}
+
+		return $schemas;
+	}
+
+	/**
+	 * @return array{file: string, dependencies: array<int, string>, version: string}
+	 */
+	private function resolvePanelScriptAsset(): array {
+		return ScriptAssetMetadata::resolve(
+			'block-panel',
+			'build/block-panel.js',
+			array(
+				'wp-api-fetch',
+				'wp-block-editor',
+				'wp-components',
+				'wp-edit-post',
+				'wp-element',
+				'wp-plugins',
+			),
+			$this->panelAssetVersion(),
+			function ( string $asset ): string {
+				return $this->panelAssetPath( $asset );
+			}
+		);
+	}
+
+	private function panelAssetUrl( string $asset ): string {
+		/** @psalm-suppress UndefinedThisPropertyFetch */
+		return $this->framework->asset_resolver()->url( $asset );
+	}
+
+	private function panelAssetPath( string $asset ): string {
+		/** @psalm-suppress UndefinedThisPropertyFetch */
+		$resolver = $this->framework->asset_resolver();
+
+		if ( $resolver instanceof AssetPathResolver ) {
+			return $resolver->path( $asset );
+		}
+
+		return PackageAssets::path( $asset );
+	}
+
+	private function panelAssetVersion(): string {
+		/** @psalm-suppress UndefinedThisPropertyFetch */
+		return $this->framework->asset_resolver()->version();
+	}
+
+	/**
+	 * @param mixed $post_types
+	 * @return array<int, string>
+	 */
+	private function normalizePostTypes( $post_types ): array {
+		$normalized = array();
+
+		foreach ( is_array( $post_types ) ? $post_types : array( $post_types ) as $post_type ) {
+			if ( ! is_scalar( $post_type ) ) {
+				continue;
+			}
+
+			$value = sanitize_key( (string) $post_type );
+
+			if ( '' === $value ) {
+				continue;
+			}
+
+			$normalized[] = $value;
+		}
+
+		return array_values( array_unique( $normalized ) );
+	}
+}

--- a/packages/AdminConfig/src/WordPress/Support/HasBlockEditorPanel.php
+++ b/packages/AdminConfig/src/WordPress/Support/HasBlockEditorPanel.php
@@ -7,7 +7,7 @@
  *   private Framework $framework — for asset resolution
  *
  * And MUST implement:
- *   private function containerTypeForBlockPanel(): string
+ *   private function container_type_for_block_panel(): string
  *
  * @package Lerm\AdminConfig
  */
@@ -32,13 +32,13 @@ trait HasBlockEditorPanel {
 	 * Hook this as: add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 	 */
 	public function enqueue_block_editor_assets(): void {
-		$ctx = $this->resolveEditorContext();
+		$ctx = $this->resolve_editor_context();
 
 		if ( empty( $ctx['post_id'] ) || '' === $ctx['post_type'] ) {
 			return;
 		}
 
-		$panel_schemas = $this->collectPanelSchemas( $ctx['post_type'], $ctx['post_id'] );
+		$panel_schemas = $this->collect_panel_schemas( $ctx['post_type'], $ctx['post_id'] );
 
 		if ( empty( $panel_schemas ) ) {
 			return;
@@ -46,12 +46,12 @@ trait HasBlockEditorPanel {
 
 		wp_enqueue_media();
 
-		$script = $this->resolvePanelScriptAsset();
+		$script = $this->resolve_panel_script_asset();
 		$handle = 'lerm-admin-config-block-panel';
 
 		wp_enqueue_script(
 			$handle,
-			$this->panelAssetUrl( $script['file'] ),
+			$this->panel_asset_url( $script['file'] ),
 			$script['dependencies'],
 			$script['version'],
 			true
@@ -59,9 +59,9 @@ trait HasBlockEditorPanel {
 
 		wp_enqueue_style(
 			$handle,
-			$this->panelAssetUrl( 'block-panel.css' ),
+			$this->panel_asset_url( 'block-panel.css' ),
 			array( 'wp-components' ),
-			$this->panelAssetVersion()
+			$this->panel_asset_version()
 		);
 
 		wp_set_script_translations(
@@ -92,7 +92,7 @@ trait HasBlockEditorPanel {
 	/**
 	 * @return array{post_id: int, post_type: string}
 	 */
-	private function resolveEditorContext(): array {
+	private function resolve_editor_context(): array {
 		$post_id   = 0;
 		$post_type = '';
 
@@ -138,13 +138,13 @@ trait HasBlockEditorPanel {
 	/**
 	 * @return array<int, array<string, mixed>>
 	 */
-	private function collectPanelSchemas( string $post_type, int $post_id ): array {
+	private function collect_panel_schemas( string $post_type, int $post_id ): array {
 		$schemas = array();
 
 		foreach ( $this->schemas as $schema ) {
 			$container = $schema->container();
 
-			if ( ! in_array( $post_type, $this->normalizePostTypes( $container['post_types'] ?? array() ), true ) ) {
+			if ( ! in_array( $post_type, $this->normalize_post_types( $container['post_types'] ?? array() ), true ) ) {
 				continue;
 			}
 
@@ -157,7 +157,7 @@ trait HasBlockEditorPanel {
 			$schemas[] = array(
 				'schemaId'      => $schema->id(),
 				'title'         => (string) ( $container['title'] ?? $schema->definition()['title'] ?? __( 'Settings', 'lerm-admin-config' ) ),
-				'containerType' => $this->containerTypeForBlockPanel(),
+				'containerType' => $this->container_type_for_block_panel(),
 				'postType'      => $post_type,
 				'context'       => array(
 					'post_id' => $post_id,
@@ -171,7 +171,7 @@ trait HasBlockEditorPanel {
 	/**
 	 * @return array{file: string, dependencies: array<int, string>, version: string}
 	 */
-	private function resolvePanelScriptAsset(): array {
+	private function resolve_panel_script_asset(): array {
 		return ScriptAssetMetadata::resolve(
 			'block-panel',
 			'build/block-panel.js',
@@ -183,19 +183,19 @@ trait HasBlockEditorPanel {
 				'wp-element',
 				'wp-plugins',
 			),
-			$this->panelAssetVersion(),
+			$this->panel_asset_version(),
 			function ( string $asset ): string {
-				return $this->panelAssetPath( $asset );
+				return $this->panel_asset_path( $asset );
 			}
 		);
 	}
 
-	private function panelAssetUrl( string $asset ): string {
+	private function panel_asset_url( string $asset ): string {
 		/** @psalm-suppress UndefinedThisPropertyFetch */
 		return $this->framework->asset_resolver()->url( $asset );
 	}
 
-	private function panelAssetPath( string $asset ): string {
+	private function panel_asset_path( string $asset ): string {
 		/** @psalm-suppress UndefinedThisPropertyFetch */
 		$resolver = $this->framework->asset_resolver();
 
@@ -206,7 +206,7 @@ trait HasBlockEditorPanel {
 		return PackageAssets::path( $asset );
 	}
 
-	private function panelAssetVersion(): string {
+	private function panel_asset_version(): string {
 		/** @psalm-suppress UndefinedThisPropertyFetch */
 		return $this->framework->asset_resolver()->version();
 	}
@@ -215,7 +215,7 @@ trait HasBlockEditorPanel {
 	 * @param mixed $post_types
 	 * @return array<int, string>
 	 */
-	private function normalizePostTypes( $post_types ): array {
+	private function normalize_post_types( $post_types ): array {
 		$normalized = array();
 
 		foreach ( is_array( $post_types ) ? $post_types : array( $post_types ) as $post_type ) {

--- a/packages/AdminConfig/tests/E2E/helpers/wp-admin.js
+++ b/packages/AdminConfig/tests/E2E/helpers/wp-admin.js
@@ -186,9 +186,15 @@ async function resetOptionsPage( page, scope = 'section', options = {} ) {
 	const resetButton = page.locator( `[data-lerm-reset="${ scope }"]` ).first();
 
 	await expect( resetButton ).toBeVisible();
-	acceptNextDialog( page );
+	const request = waitForAdminConfigTransport( page, 'reset', options );
+	await resetButton.click();
 
-	return clickAndWaitForAdminConfigTransport( page, resetButton, 'reset', options );
+	// Click the Confirm button in the wp.components.Modal (replaced window.confirm).
+	const confirmButton = page.locator( '.components-modal__content button.is-destructive, .components-modal__content button.is-primary' ).first();
+	await expect( confirmButton ).toBeVisible( { timeout: 5_000 } );
+	await confirmButton.click();
+
+	return request;
 }
 
 async function exportBackupSnapshot( page, options = {} ) {
@@ -212,9 +218,15 @@ async function importBackupSnapshot( page, json, options = {} ) {
 	const button = page.locator( '[data-lerm-backup-import]' ).first();
 
 	await input.fill( json );
-	acceptNextDialog( page );
+	const request = waitForAdminConfigTransport( page, 'import', options );
+	await button.click();
 
-	return clickAndWaitForAdminConfigTransport( page, button, 'import', options );
+	// Click the Confirm button in the wp.components.Modal (replaced window.confirm).
+	const confirmButton = page.locator( '.components-modal__content button.is-destructive, .components-modal__content button.is-primary' ).first();
+	await expect( confirmButton ).toBeVisible( { timeout: 5_000 } );
+	await confirmButton.click();
+
+	return request;
 }
 
 async function submitClassicForm( page, submitSelector = '#submit' ) {

--- a/packages/AdminConfig/tests/Smoke/ExamplesSmokeTest.php
+++ b/packages/AdminConfig/tests/Smoke/ExamplesSmokeTest.php
@@ -32,8 +32,9 @@ final class ExamplesSmokeTest extends TestCase {
 		$this->assertTrue( $runtime->has( 'acme-demo-profile' ) );
 		$this->assertTrue( $runtime->has( 'acme-demo-taxonomy' ) );
 		$this->assertTrue( $runtime->has( 'acme-theme-style-kit' ) );
+		$this->assertTrue( $runtime->has( 'acme-demo-block-editor-panel' ) );
 		$this->assertTrue( $runtime->has( 'acme-theme-hero-metabox' ) );
 		$this->assertTrue( $runtime->has_data_source( 'tone_presets' ) );
-		$this->assertCount( 7, $runtime->schemas() );
+		$this->assertCount( 8, $runtime->schemas() );
 	}
 }

--- a/packages/AdminConfig/tests/Unit/BlockEditorPanelTest.php
+++ b/packages/AdminConfig/tests/Unit/BlockEditorPanelTest.php
@@ -12,10 +12,76 @@ namespace Lerm\AdminConfig\Tests\Unit;
 use Lerm\AdminConfig\Framework\Contracts\AssetResolver;
 use Lerm\AdminConfig\Framework\Framework;
 use Lerm\AdminConfig\Tests\Support\TestCase;
+use Lerm\AdminConfig\WordPress\Containers\BlockEditorPanelContainer;
 use Lerm\AdminConfig\WordPress\Containers\MetaboxContainer;
 use Lerm\AdminConfig\WordPress\Runtime;
 
 final class BlockEditorPanelTest extends TestCase {
+
+	public function testBlockEditorPanelContainerIsRegisteredInRuntime(): void {
+		$runtime = $this->runtime_with_metabox_schema();
+		$runtime->boot();
+
+		$this->assertArrayHasKey( 'block_editor_panel', $runtime->containers() );
+		$this->assertInstanceOf( BlockEditorPanelContainer::class, $runtime->containers()['block_editor_panel'] );
+	}
+
+	public function testBlockEditorPanelTypeSchemaMountsCorrectly(): void {
+		$runtime = $this->runtime_with_block_editor_panel_schema();
+		$runtime->boot();
+
+		$this->assertArrayHasKey( 'enqueue_block_editor_assets', $GLOBALS['lerm_admin_config_actions'] );
+	}
+
+	public function testBlockEditorPanelEnqueuesForMatchingPostType(): void {
+		$runtime = $this->runtime_with_block_editor_panel_schema();
+		$runtime->boot();
+
+		$GLOBALS['lerm_admin_config_current_screen'] = (object) array(
+			'post_type' => 'post',
+		);
+		$GLOBALS['post']                             = (object) array(
+			'ID'        => 123,
+			'post_type' => 'post',
+		);
+
+		$container = $runtime->containers()['block_editor_panel'];
+		$this->assertInstanceOf( BlockEditorPanelContainer::class, $container );
+		$container->enqueue_block_editor_assets();
+
+		$script = $GLOBALS['lerm_admin_config_enqueued_scripts']['lerm-admin-config-block-panel'] ?? null;
+		$this->assertIsArray( $script );
+		$this->assertTrue( $GLOBALS['lerm_admin_config_media_enqueued'] ?? false );
+
+		$inline = $GLOBALS['lerm_admin_config_inline_scripts']['lerm-admin-config-block-panel'][0] ?? null;
+		$this->assertIsArray( $inline );
+		$this->assertSame( 'before', $inline['position'] );
+
+		$payload = $this->extract_inline_payload( (string) $inline['data'] );
+		$this->assertSame( 'unit-block-editor-panel', $payload['schemas'][0]['schemaId'] );
+		$this->assertSame( 'block_editor_panel', $payload['schemas'][0]['containerType'] );
+		$this->assertSame( 'post', $payload['schemas'][0]['postType'] );
+		$this->assertSame( 123, $payload['schemas'][0]['context']['post_id'] );
+	}
+
+	public function testBlockEditorPanelSkipsUnmatchedPostType(): void {
+		$runtime = $this->runtime_with_block_editor_panel_schema();
+		$runtime->boot();
+
+		$GLOBALS['lerm_admin_config_current_screen'] = (object) array(
+			'post_type' => 'page',
+		);
+		$GLOBALS['post']                             = (object) array(
+			'ID'        => 123,
+			'post_type' => 'page',
+		);
+
+		$container = $runtime->containers()['block_editor_panel'];
+		$this->assertInstanceOf( BlockEditorPanelContainer::class, $container );
+		$container->enqueue_block_editor_assets();
+
+		$this->assertArrayNotHasKey( 'lerm-admin-config-block-panel', $GLOBALS['lerm_admin_config_enqueued_scripts'] );
+	}
 
 	public function testMetaboxRuntimeRegistersBlockEditorAssetHook(): void {
 		$runtime = $this->runtime_with_metabox_schema();
@@ -137,6 +203,52 @@ final class BlockEditorPanelTest extends TestCase {
 		$container->enqueue_block_editor_assets();
 
 		$this->assertArrayNotHasKey( 'lerm-admin-config-block-panel', $GLOBALS['lerm_admin_config_enqueued_scripts'] );
+	}
+
+	private function runtime_with_block_editor_panel_schema(): Runtime {
+		$runtime = new Runtime(
+			new Framework(
+				new class() implements AssetResolver {
+					public function url( string $filename ): string {
+						return 'https://example.test/assets/' . ltrim( $filename, '/' );
+					}
+
+					public function version(): string {
+						return 'unit-version';
+					}
+				}
+			)
+		);
+
+		$runtime->register(
+			array(
+				'id'        => 'unit-block-editor-panel',
+				'title'     => 'Unit Block Editor Panel',
+				'container' => array(
+					'type'       => 'block_editor_panel',
+					'title'      => 'Unit Block Editor Panel',
+					'post_types' => array( 'post' ),
+					'capability' => 'edit_post',
+				),
+				'store'     => array(
+					'type' => 'post_meta',
+					'key'  => '_unit_block_editor_panel',
+				),
+				'sections'  => array(
+					'display' => array(
+						'fields' => array(
+							array(
+								'id'      => 'headline',
+								'type'    => 'text',
+								'default' => '',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		return $runtime;
 	}
 
 	private function runtime_with_metabox_schema(): Runtime {

--- a/packages/AdminConfig/tests/bootstrap.php
+++ b/packages/AdminConfig/tests/bootstrap.php
@@ -663,6 +663,17 @@ if ( ! function_exists( 'wp_localize_script' ) ) {
 	}
 }
 
+if ( ! function_exists( 'wp_set_script_translations' ) ) {
+	function wp_set_script_translations( string $handle, string $domain = 'default', string $path = '' ): bool {
+		$GLOBALS['lerm_admin_config_script_translations'][ $handle ] = array(
+			'domain' => $domain,
+			'path'   => $path,
+		);
+
+		return true;
+	}
+}
+
 if ( ! function_exists( 'wp_parse_args' ) ) {
 	function wp_parse_args( $args, array $defaults = array() ): array {
 		$parsed = is_array( $args ) ? $args : array();


### PR DESCRIPTION
## Summary

Replace 4 `window.wp.*` global accesses in `block-panel/index.js` with `require('@wordpress/*')` npm imports, enabling tree-shaking and making dependencies explicit.

## Changes

| Before | After |
|--------|-------|
| `window.wp.components` | `require('@wordpress/components')` |
| `window.wp.data.dispatch()` | `require('@wordpress/data').dispatch()` |
| `window.wp.plugins` | `require('@wordpress/plugins')` |
| `window.wp.editPost`/`wp.editor` + `wp.element` | `require('@wordpress/editor')` + `require('@wordpress/element')` |

Also added `@wordpress/components ^28.0.0` to devDependencies.

All requires use try-catch fallback for Node.js test environment compatibility.
`DependencyExtractionWebpackPlugin` auto-detects the imports and updates `block-panel.asset.php` dependencies.

## Files Changed

- `packages/AdminConfig/package.json` — add `@wordpress/components`
- `packages/AdminConfig/package-lock.json` — lockfile update
- `packages/AdminConfig/resources/block-panel/index.js` — 4 global accesses → require

## CI Results

| Check | Result |
|-------|--------|
| `npm run build` | passed |
| `node tools/test-js-runtime.js` | passed |
| `vendor/bin/phpunit` | 94/94 passed |

## Related

Part of Phase 2 wp-scripts toolchain modernization.
Depends on #74 (wp.data store + i18n bridge).