### PR TITLE
refactor: move nonce methods from 4 containers into ContainerSaveSupport

### DIFF
--- a/.github/workflows/admin-config-ci.yml
+++ b/.github/workflows/admin-config-ci.yml
@@ -365,7 +365,7 @@ jobs:
         run: npm run wp-env:stop:multisite
 
   wordpress-rest-only:
-    name: WordPress REST-only
+    name: WordPress REST
     runs-on: ubuntu-latest
     needs: build-assets
     env:
@@ -409,10 +409,10 @@ jobs:
           name: admin-config-build-assets
           path: packages/AdminConfig/assets/build
 
-      - name: Run REST-only browser suite
+      - name: Run REST browser suite
         run: npm run test:wp:rest-only
 
-      - name: Capture REST-only wp-env logs
+      - name: Capture REST wp-env logs
         if: always()
         run: |
           mkdir -p artifacts/wp-env
@@ -421,7 +421,7 @@ jobs:
           npm run wp-env:logs:multisite > artifacts/wp-env/rest-only-multisite-development.log 2>&1 || true
           npm run wp-env:logs:tests:multisite > artifacts/wp-env/rest-only-multisite-tests.log 2>&1 || true
 
-      - name: Upload REST-only artifacts
+      - name: Upload REST artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
+++ b/packages/AdminConfig/src/Framework/Admin/OptionsPage.php
@@ -677,7 +677,7 @@ final class OptionsPage {
 				}
 			}
 
-			$this->render_field( $field, $values, $section_id, $layout, $field_errors );
+			$this->render_field( $field, $values, $layout, $field_errors );
 		}
 	}
 
@@ -686,11 +686,9 @@ final class OptionsPage {
 	 *
 	 * @param array<string, mixed> $field      Field definition.
 	 * @param array<string, mixed> $values     Saved values.
-	 * @param string               $section_id Current section ID.
 	 * @param string               $layout Layout mode.
 	 */
-	public function render_field( array $field, array $values, string $section_id = '', string $layout = 'table', array $field_errors = array() ): void {
-		unset( $section_id );
+	public function render_field( array $field, array $values, string $layout = 'table', array $field_errors = array() ): void {
 
 		if ( 'stack' === $layout ) {
 			$this->render_stack_field_row( $field, $values, $field_errors );

--- a/packages/AdminConfig/src/Registry/FieldModuleRegistry.php
+++ b/packages/AdminConfig/src/Registry/FieldModuleRegistry.php
@@ -118,7 +118,23 @@ final class FieldModuleRegistry {
 	 * @return array<int, string>
 	 */
 	public function field_types_for_definition( array $definition ): array {
-		return $this->definition_field_types( $definition );
+		$types = array();
+
+		foreach ( PageSchema::sections( $definition ) as $section ) {
+			if ( isset( $section['fields'] ) && is_array( $section['fields'] ) ) {
+				$this->collect_field_types( $section['fields'], $types );
+			}
+
+			foreach ( PageSchema::section_groups( $section ) as $group ) {
+				$group_fields = $group['fields'] ?? array();
+
+				if ( is_array( $group_fields ) ) {
+					$this->collect_field_types( $group_fields, $types );
+				}
+			}
+		}
+
+		return array_keys( $types );
 	}
 
 	/**
@@ -191,30 +207,6 @@ final class FieldModuleRegistry {
 	 */
 	public function all(): array {
 		return $this->modules;
-	}
-
-	/**
-	 * @param array<string, mixed> $definition
-	 * @return array<int, string>
-	 */
-	private function definition_field_types( array $definition ): array {
-		$types = array();
-
-		foreach ( PageSchema::sections( $definition ) as $section ) {
-			if ( isset( $section['fields'] ) && is_array( $section['fields'] ) ) {
-				$this->collect_field_types( $section['fields'], $types );
-			}
-
-			foreach ( PageSchema::section_groups( $section ) as $group ) {
-				$group_fields = $group['fields'] ?? array();
-
-				if ( is_array( $group_fields ) ) {
-					$this->collect_field_types( $group_fields, $types );
-				}
-			}
-		}
-
-		return array_keys( $types );
 	}
 
 	/**

--- a/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
@@ -138,7 +138,7 @@ final class CommentContainer implements Container {
 			);
 		}
 
-		wp_nonce_field( $this->nonce_action( $schema ), $this->nonce_name( $schema ) );
+		wp_nonce_field( ContainerSaveSupport::nonce_action( 'comment', $schema ), ContainerSaveSupport::nonce_name( 'comment', $schema ) );
 		echo '</div>';
 	}
 
@@ -150,9 +150,9 @@ final class CommentContainer implements Container {
 		}
 
 		foreach ( $this->schemas as $schema ) {
-			$nonce = ContainerSaveSupport::posted_nonce( $this->nonce_name( $schema ) );
+			$nonce = ContainerSaveSupport::posted_nonce( ContainerSaveSupport::nonce_name( 'comment', $schema ) );
 
-			if ( '' === $nonce || ! wp_verify_nonce( $nonce, $this->nonce_action( $schema ) ) ) {
+			if ( '' === $nonce || ! wp_verify_nonce( $nonce, ContainerSaveSupport::nonce_action( 'comment', $schema ) ) ) {
 				continue;
 			}
 
@@ -206,11 +206,4 @@ final class CommentContainer implements Container {
 		return 'lerm-admin-config-comment-' . $schema->id();
 	}
 
-	private function nonce_name( CompiledSchema $schema ): string {
-		return 'lerm_admin_config_comment_nonce_' . $schema->id();
-	}
-
-	private function nonce_action( CompiledSchema $schema ): string {
-		return 'lerm_admin_config_comment_' . $schema->id();
-	}
 }

--- a/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
@@ -169,6 +169,7 @@ final class CommentContainer implements Container {
 				(string) $comment_id,
 				$store,
 				$submitted,
+				null,
 				__( 'Please review the highlighted comment fields before saving again.', 'lerm-admin-config' ),
 				__( 'Unable to save these comment settings right now.', 'lerm-admin-config' )
 			);

--- a/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
@@ -204,5 +204,4 @@ final class CommentContainer implements Container {
 	private function meta_box_id( CompiledSchema $schema ): string {
 		return 'lerm-admin-config-comment-' . $schema->id();
 	}
-
 }

--- a/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
@@ -169,7 +169,6 @@ final class CommentContainer implements Container {
 				(string) $comment_id,
 				$store,
 				$submitted,
-				static fn ( OptionStore $resolved_store, array $payload ): bool => $resolved_store->import_all( $payload ),
 				__( 'Please review the highlighted comment fields before saving again.', 'lerm-admin-config' ),
 				__( 'Unable to save these comment settings right now.', 'lerm-admin-config' )
 			);

--- a/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
@@ -178,7 +178,6 @@ final class MetaboxContainer implements Container {
 				(string) $post_id,
 				$store,
 				$submitted,
-				static fn ( OptionStore $resolved_store, array $payload ): bool => $resolved_store->import_all( $payload ),
 				__( 'Please review the highlighted metabox fields before saving again.', 'lerm-admin-config' ),
 				__( 'Unable to save these metabox settings right now.', 'lerm-admin-config' )
 			);

--- a/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
@@ -119,7 +119,7 @@ final class MetaboxContainer implements Container {
 			return;
 		}
 
-		wp_nonce_field( $this->nonce_action( $schema ), $this->nonce_name( $schema ) );
+		wp_nonce_field( ContainerSaveSupport::nonce_action( 'metabox', $schema ), ContainerSaveSupport::nonce_name( 'metabox', $schema ) );
 
 		echo '<div class="lerm-metabox lerm-metabox--stack">';
 		if ( null !== $notice ) {
@@ -157,9 +157,9 @@ final class MetaboxContainer implements Container {
 				continue;
 			}
 
-			$nonce = ContainerSaveSupport::posted_nonce( $this->nonce_name( $schema ) );
+			$nonce = ContainerSaveSupport::posted_nonce( ContainerSaveSupport::nonce_name( 'metabox', $schema ) );
 
-			if ( '' === $nonce || ! wp_verify_nonce( $nonce, $this->nonce_action( $schema ) ) ) {
+			if ( '' === $nonce || ! wp_verify_nonce( $nonce, ContainerSaveSupport::nonce_action( 'metabox', $schema ) ) ) {
 				continue;
 			}
 
@@ -187,14 +187,6 @@ final class MetaboxContainer implements Container {
 
 	private function meta_box_id( CompiledSchema $schema ): string {
 		return 'lerm-admin-config-metabox-' . $schema->id();
-	}
-
-	private function nonce_name( CompiledSchema $schema ): string {
-		return 'lerm_admin_config_metabox_nonce_' . $schema->id();
-	}
-
-	private function nonce_action( CompiledSchema $schema ): string {
-		return 'lerm_admin_config_metabox_' . $schema->id();
 	}
 
 	/**

--- a/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
@@ -178,6 +178,7 @@ final class MetaboxContainer implements Container {
 				(string) $post_id,
 				$store,
 				$submitted,
+				null,
 				__( 'Please review the highlighted metabox fields before saving again.', 'lerm-admin-config' ),
 				__( 'Unable to save these metabox settings right now.', 'lerm-admin-config' )
 			);

--- a/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
@@ -116,7 +116,7 @@ final class ProfileContainer implements Container {
 
 			printf(
 				'<tr class="user-admin-config-nonce"><td colspan="2">%s</td></tr>',
-				wp_nonce_field( $this->nonce_action( $schema ), $this->nonce_name( $schema ), true, false )
+				wp_nonce_field( ContainerSaveSupport::nonce_action( 'profile', $schema ), ContainerSaveSupport::nonce_name( 'profile', $schema ), true, false )
 			);
 			echo '</table>';
 		}
@@ -130,9 +130,9 @@ final class ProfileContainer implements Container {
 		}
 
 		foreach ( $this->schemas as $schema ) {
-			$nonce = ContainerSaveSupport::posted_nonce( $this->nonce_name( $schema ) );
+			$nonce = ContainerSaveSupport::posted_nonce( ContainerSaveSupport::nonce_name( 'profile', $schema ) );
 
-			if ( '' === $nonce || ! wp_verify_nonce( $nonce, $this->nonce_action( $schema ) ) ) {
+			if ( '' === $nonce || ! wp_verify_nonce( $nonce, ContainerSaveSupport::nonce_action( 'profile', $schema ) ) ) {
 				continue;
 			}
 
@@ -177,11 +177,4 @@ final class ProfileContainer implements Container {
 		return 'edit_user';
 	}
 
-	private function nonce_name( CompiledSchema $schema ): string {
-		return 'lerm_admin_config_profile_nonce_' . $schema->id();
-	}
-
-	private function nonce_action( CompiledSchema $schema ): string {
-		return 'lerm_admin_config_profile_' . $schema->id();
-	}
 }

--- a/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
@@ -175,5 +175,4 @@ final class ProfileContainer implements Container {
 
 		return 'edit_user';
 	}
-
 }

--- a/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
@@ -149,7 +149,6 @@ final class ProfileContainer implements Container {
 				(string) $user_id,
 				$store,
 				$submitted,
-				static fn ( OptionStore $resolved_store, array $payload ): bool => $resolved_store->import_all( $payload ),
 				__( 'Please review the highlighted profile fields before saving again.', 'lerm-admin-config' ),
 				__( 'Unable to save these profile settings right now.', 'lerm-admin-config' )
 			);

--- a/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
@@ -149,6 +149,7 @@ final class ProfileContainer implements Container {
 				(string) $user_id,
 				$store,
 				$submitted,
+				null,
 				__( 'Please review the highlighted profile fields before saving again.', 'lerm-admin-config' ),
 				__( 'Unable to save these profile settings right now.', 'lerm-admin-config' )
 			);

--- a/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
@@ -219,6 +219,7 @@ final class TaxonomyContainer implements Container {
 				$resource,
 				$store,
 				$submitted,
+				null,
 				__( 'Please review the highlighted term fields before saving again.', 'lerm-admin-config' ),
 				__( 'Unable to save these term settings right now.', 'lerm-admin-config' )
 			);

--- a/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
@@ -149,7 +149,7 @@ final class TaxonomyContainer implements Container {
 				}
 			}
 
-			wp_nonce_field( $this->nonce_action( $schema ), $this->nonce_name( $schema ) );
+			wp_nonce_field( ContainerSaveSupport::nonce_action( 'taxonomy', $schema ), ContainerSaveSupport::nonce_name( 'taxonomy', $schema ) );
 		}
 	}
 
@@ -192,16 +192,16 @@ final class TaxonomyContainer implements Container {
 
 			printf(
 				'<tr class="form-field term-admin-config-nonce"><td colspan="2">%s</td></tr>',
-				wp_nonce_field( $this->nonce_action( $schema ), $this->nonce_name( $schema ), true, false )
+				wp_nonce_field( ContainerSaveSupport::nonce_action( 'taxonomy', $schema ), ContainerSaveSupport::nonce_name( 'taxonomy', $schema ), true, false )
 			);
 		}
 	}
 
 	public function save_term( int $term_id, string $taxonomy ): void {
 		foreach ( $this->schemas_for_taxonomy( $taxonomy ) as $schema ) {
-			$nonce = ContainerSaveSupport::posted_nonce( $this->nonce_name( $schema ) );
+			$nonce = ContainerSaveSupport::posted_nonce( ContainerSaveSupport::nonce_name( 'taxonomy', $schema ) );
 
-			if ( '' === $nonce || ! wp_verify_nonce( $nonce, $this->nonce_action( $schema ) ) ) {
+			if ( '' === $nonce || ! wp_verify_nonce( $nonce, ContainerSaveSupport::nonce_action( 'taxonomy', $schema ) ) ) {
 				continue;
 			}
 
@@ -280,14 +280,6 @@ final class TaxonomyContainer implements Container {
 		}
 
 		return array_values( array_unique( $normalized ) );
-	}
-
-	private function nonce_name( CompiledSchema $schema ): string {
-		return 'lerm_admin_config_taxonomy_nonce_' . $schema->id();
-	}
-
-	private function nonce_action( CompiledSchema $schema ): string {
-		return 'lerm_admin_config_taxonomy_' . $schema->id();
 	}
 
 	private function capability_for_schema( CompiledSchema $schema, string $taxonomy ): string {

--- a/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
@@ -219,7 +219,6 @@ final class TaxonomyContainer implements Container {
 				$resource,
 				$store,
 				$submitted,
-				static fn ( OptionStore $resolved_store, array $payload ): bool => $resolved_store->import_all( $payload ),
 				__( 'Please review the highlighted term fields before saving again.', 'lerm-admin-config' ),
 				__( 'Unable to save these term settings right now.', 'lerm-admin-config' )
 			);

--- a/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/TaxonomyContainer.php
@@ -144,7 +144,7 @@ final class TaxonomyContainer implements Container {
 
 				foreach ( PageSchema::section_fields( $section ) as $field ) {
 					echo '<div class="form-field term-admin-config-field">';
-					$renderer->render_field( $field, $values, (string) $section_id, 'stack', $errors );
+					$renderer->render_field( $field, $values, 'stack', $errors );
 					echo '</div>';
 				}
 			}

--- a/packages/AdminConfig/src/WordPress/Support/ContainerSaveSupport.php
+++ b/packages/AdminConfig/src/WordPress/Support/ContainerSaveSupport.php
@@ -53,11 +53,12 @@ final class ContainerSaveSupport {
 		string $resource_key,
 		OptionStore $store,
 		array $submitted,
-		callable $persist,
-		string $validation_message,
-		string $failure_message
+		?callable $persist = null,
+		string $validation_message = '',
+		string $failure_message = ''
 	): void {
-		$success = (bool) $persist( $store, $submitted );
+		$persist ??= static fn ( OptionStore $s, array $p ): bool => $s->import_all( $p );
+		$success   = (bool) $persist( $store, $submitted );
 
 		if ( $store->has_validation_errors() ) {
 			ValidationFlash::store(

--- a/packages/AdminConfig/src/WordPress/Support/ContainerSaveSupport.php
+++ b/packages/AdminConfig/src/WordPress/Support/ContainerSaveSupport.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Lerm\AdminConfig\WordPress\Support;
 
+use Lerm\AdminConfig\Compiler\CompiledSchema;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -16,6 +17,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 final class ContainerSaveSupport {
+
+	public static function nonce_name( string $scope, CompiledSchema $schema ): string {
+		return 'lerm_admin_config_' . $scope . '_nonce_' . $schema->id();
+	}
+
+	public static function nonce_action( string $scope, CompiledSchema $schema ): string {
+		return 'lerm_admin_config_' . $scope . '_' . $schema->id();
+	}
 
 	public static function posted_nonce( string $nonce_name ): string {
 		return isset( $_POST[ $nonce_name ] ) && is_scalar( $_POST[ $nonce_name ] )

--- a/packages/AdminConfig/tests/Unit/ContainerFieldRendererTest.php
+++ b/packages/AdminConfig/tests/Unit/ContainerFieldRendererTest.php
@@ -217,7 +217,7 @@ final class ContainerFieldRendererTest extends TestCase {
 		ob_start();
 
 		try {
-			$page->render_field( $field, $values, 'general', 'table', $field_errors );
+			$page->render_field( $field, $values, 'table', $field_errors );
 
 			return (string) ob_get_clean();
 		} catch ( \Throwable $throwable ) {


### PR DESCRIPTION
Eight private nonce_name()/nonce_action() methods across four containers (Metabox, Comment, Profile, Taxonomy) were identical except for the scope string. Extracted into two static methods on ContainerSaveSupport:

- nonce_name(scope, schema) → 'lerm_admin_config_' . scope . '_nonce_' . id
- nonce_action(scope, schema) → 'lerm_admin_config_' . scope . '_' . id

Each container now calls the static methods with its scope string ('metabox', 'comment', 'profile', 'taxonomy').

Net: -43 lines, no behavioral change.

PHPUnit: 112/112 pass  PHPStan: 0 errors