### PR TITLE
fix: remove static routes_registered guard to fix flaky REST endpoint…

### DIFF
--- a/packages/AdminConfig/src/Rest/RestEndpoints.php
+++ b/packages/AdminConfig/src/Rest/RestEndpoints.php
@@ -30,12 +30,6 @@ final class RestEndpoints {
 	 */
 	private static array $runtimes = array();
 
-	/**
-	 * Tracks whether routes have been registered to prevent duplicate
-	 * registration when multiple RestEndpoints instances exist.
-	 */
-	private static bool $routes_registered = false;
-
 	public function __construct(
 		private Runtime $runtime
 	) {
@@ -43,11 +37,7 @@ final class RestEndpoints {
 
 	public function register(): void {
 		self::$runtimes[ spl_object_id( $this->runtime ) ] = \WeakReference::create( $this->runtime );
-
-		if ( ! self::$routes_registered ) {
-			add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
-			self::$routes_registered = true;
-		}
+		add_action( 'rest_api_init', array( self::class, 'register_routes' ) );
 	}
 
 	public static function register_routes(): void {


### PR DESCRIPTION
… tests

The static $routes_registered flag prevented add_action('rest_api_init', ...) from being called for subsequent Runtime instances, causing tests that rely on REST route registration to intermittently fail depending on execution order.

WordPress's register_rest_route() already handles deduplication, so the manual guard was redundant. Removed it so the action is always registered.