### PR TITLE
refactor: extract shared helper methods to reduce boilerplate

### DIFF
--- a/packages/AdminConfig/src/Framework/FieldTypes/AdvancedFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/AdvancedFieldTypes.php
@@ -13,6 +13,7 @@ use Lerm\AdminConfig\Framework\Admin\OptionsPage;
 use Lerm\AdminConfig\Framework\FieldTypes\Support\NestedFieldSanitizer;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
 use Lerm\AdminConfig\Framework\Support\PageSchema;
+use Lerm\AdminConfig\Framework\FieldTypes\Support\FieldRenderHelpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -70,8 +71,8 @@ final class AdvancedFieldTypes {
 					$field_name,
 					$input_id,
 					'',
-					self::name_attr( $name_template ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( $name_template ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ): string {
@@ -515,13 +516,5 @@ final class AdvancedFieldTypes {
 			'<p class="description" style="color:#b91c1c;font-style:italic">%s</p>',
 			esc_html( $message )
 		);
-	}
-
-	private static function name_attr( string $template ): string {
-		return '' !== $template ? ' data-name-template="' . esc_attr( $template ) . '"' : '';
-	}
-
-	private static function id_attr( string $template ): string {
-		return '' !== $template ? ' data-id-template="' . esc_attr( $template ) . '"' : '';
 	}
 }

--- a/packages/AdminConfig/src/Framework/FieldTypes/BuiltinFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/BuiltinFieldTypes.php
@@ -12,6 +12,7 @@ namespace Lerm\AdminConfig\Framework\FieldTypes;
 use Lerm\AdminConfig\Framework\Admin\OptionsPage;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
 use Lerm\AdminConfig\Framework\Support\PageSchema;
+use Lerm\AdminConfig\Framework\FieldTypes\Support\FieldRenderHelpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -62,8 +63,8 @@ final class BuiltinFieldTypes {
 					$input_id,
 					'text',
 					'',
-					self::name_attr( $name_template ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( $name_template ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
@@ -99,8 +100,8 @@ final class BuiltinFieldTypes {
 					$input_id,
 					'url',
 					'',
-					self::name_attr( $name_template ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( $name_template ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
@@ -134,8 +135,8 @@ final class BuiltinFieldTypes {
 					$field_name,
 					$input_id,
 					'',
-					self::name_attr( $name_template ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( $name_template ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
@@ -168,7 +169,7 @@ final class BuiltinFieldTypes {
 					$value,
 					$field_name,
 					$input_id,
-					self::name_attr( $name_template ) . self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( $name_template ) . FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
@@ -201,8 +202,8 @@ final class BuiltinFieldTypes {
 					esc_attr( $input_id ),
 					esc_attr( $field_name ),
 					esc_attr( PageSchema::scalar_value( $value ) ),
-					self::name_attr( $name_template ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( $name_template ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
@@ -239,8 +240,8 @@ final class BuiltinFieldTypes {
 					$field_name,
 					$input_id,
 					'',
-					self::name_attr( $name_template ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( $name_template ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
@@ -262,7 +263,7 @@ final class BuiltinFieldTypes {
 				self::render_choice_group( $field, $value, $field_name, true, '', '', $type );
 			},
 			'render_nested' => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ) use ( $type ): void {
-				self::render_choice_group( $field, $value, $field_name, false, self::name_attr( $name_template ), self::id_attr( $id_template ), $type );
+				self::render_choice_group( $field, $value, $field_name, false, FieldRenderHelpers::name_attr( $name_template ), FieldRenderHelpers::id_attr( $id_template ), $type );
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
 				return self::sanitize_select_like( $field, $value, $strict );
@@ -449,7 +450,7 @@ final class BuiltinFieldTypes {
 		$current_value    = $multiple ? '' : PageSchema::scalar_value( $value );
 		$select_name_attr = $multiple && '' !== $name_template
 			? ' data-name-template="' . esc_attr( $name_template . '[]' ) . '"'
-			: self::name_attr( $name_template );
+			: FieldRenderHelpers::name_attr( $name_template );
 
 		printf(
 			'<select id="%1$s" name="%2$s" class="regular-text"%3$s%4$s%5$s%6$s>',
@@ -458,7 +459,7 @@ final class BuiltinFieldTypes {
 			$multiple ? ' multiple="multiple"' : '',
 			$multiple ? ' size="' . esc_attr( (string) min( max( count( $choices ), 4 ), 10 ) ) . '"' : '',
 			$select_name_attr,
-			$is_root ? ' data-lerm-controller="1"' : self::id_attr( $id_template )
+			$is_root ? ' data-lerm-controller="1"' : FieldRenderHelpers::id_attr( $id_template )
 		);
 
 		foreach ( $choices as $choice_value => $choice_label ) {
@@ -615,13 +616,5 @@ final class BuiltinFieldTypes {
 		}
 
 		return $fallback;
-	}
-
-	private static function name_attr( string $name_template ): string {
-		return '' !== $name_template ? ' data-name-template="' . esc_attr( $name_template ) . '"' : '';
-	}
-
-	private static function id_attr( string $id_template ): string {
-		return '' !== $id_template ? ' data-id-template="' . esc_attr( $id_template ) . '"' : '';
 	}
 }

--- a/packages/AdminConfig/src/Framework/FieldTypes/DesignFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/DesignFieldTypes.php
@@ -12,6 +12,7 @@ namespace Lerm\AdminConfig\Framework\FieldTypes;
 use Lerm\AdminConfig\Framework\Admin\OptionsPage;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
 use Lerm\AdminConfig\Framework\Support\PageSchema;
+use Lerm\AdminConfig\Framework\FieldTypes\Support\FieldRenderHelpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -274,10 +275,10 @@ final class DesignFieldTypes {
 					'button_text' => (string) ( $field['background_image_button_text'] ?? __( 'Choose image', 'lerm-admin-config' ) ),
 				),
 				$values['background-image'] ?? array(),
-				self::sub_name( $field_name, 'background-image' ),
-				self::sub_id( $input_id, 'background-image' ),
-				self::name_attr( self::sub_template( $name_template, 'background-image' ) ),
-				self::id_attr( self::sub_id_template( $id_template, 'background-image' ) )
+				FieldRenderHelpers::sub_name( $field_name, 'background-image' ),
+				FieldRenderHelpers::sub_id( $input_id, 'background-image' ),
+				FieldRenderHelpers::name_attr( FieldRenderHelpers::sub_template( $name_template, 'background-image' ) ),
+				FieldRenderHelpers::id_attr( FieldRenderHelpers::sub_id_template( $id_template, 'background-image' ) )
 			);
 			echo '</div>';
 		}
@@ -434,11 +435,11 @@ final class DesignFieldTypes {
 		echo '<label class="lerm-composite__item"><span class="lerm-composite__label">' . esc_html( $label ) . '</span><span class="lerm-composite__input">';
 		printf(
 			'<input type="number" id="%1$s" name="%2$s" value="%3$s" class="small-text"%4$s%5$s step="any">%6$s',
-			esc_attr( self::sub_id( $input_id, $key ) ),
-			esc_attr( self::sub_name( $field_name, $key ) ),
+			esc_attr( FieldRenderHelpers::sub_id( $input_id, $key ) ),
+			esc_attr( FieldRenderHelpers::sub_name( $field_name, $key ) ),
 			esc_attr( self::numeric_fragment( $values[ $key ] ?? '' ) ),
-			self::name_attr( self::sub_template( $name_template, $key ) ),
-			self::id_attr( self::sub_id_template( $id_template, $key ) ),
+			FieldRenderHelpers::name_attr( FieldRenderHelpers::sub_template( $name_template, $key ) ),
+			FieldRenderHelpers::id_attr( FieldRenderHelpers::sub_id_template( $id_template, $key ) ),
 			'' !== $unit ? '<span class="lerm-composite__unit">' . esc_html( $unit ) . '</span>' : ''
 		);
 		echo '</span></label>';
@@ -448,11 +449,11 @@ final class DesignFieldTypes {
 		echo '<label class="lerm-composite__item"><span class="lerm-composite__label">' . esc_html( $label ) . '</span>';
 		printf(
 			'<input type="text" id="%1$s" name="%2$s" value="%3$s" class="regular-text lerm-color-field"%4$s%5$s>',
-			esc_attr( self::sub_id( $input_id, $key ) ),
-			esc_attr( self::sub_name( $field_name, $key ) ),
+			esc_attr( FieldRenderHelpers::sub_id( $input_id, $key ) ),
+			esc_attr( FieldRenderHelpers::sub_name( $field_name, $key ) ),
 			esc_attr( $value ),
-			self::name_attr( self::sub_template( $name_template, $key ) ),
-			self::id_attr( self::sub_id_template( $id_template, $key ) )
+			FieldRenderHelpers::name_attr( FieldRenderHelpers::sub_template( $name_template, $key ) ),
+			FieldRenderHelpers::id_attr( FieldRenderHelpers::sub_id_template( $id_template, $key ) )
 		);
 		echo '</label>';
 	}
@@ -461,10 +462,10 @@ final class DesignFieldTypes {
 		echo '<label class="lerm-composite__item"><span class="lerm-composite__label">' . esc_html( $label ) . '</span>';
 		printf(
 			'<select id="%1$s" name="%2$s" class="regular-text"%3$s%4$s>',
-			esc_attr( self::sub_id( $input_id, $key ) ),
-			esc_attr( self::sub_name( $field_name, $key ) ),
-			self::name_attr( self::sub_template( $name_template, $key ) ),
-			self::id_attr( self::sub_id_template( $id_template, $key ) )
+			esc_attr( FieldRenderHelpers::sub_id( $input_id, $key ) ),
+			esc_attr( FieldRenderHelpers::sub_name( $field_name, $key ) ),
+			FieldRenderHelpers::name_attr( FieldRenderHelpers::sub_template( $name_template, $key ) ),
+			FieldRenderHelpers::id_attr( FieldRenderHelpers::sub_id_template( $id_template, $key ) )
 		);
 		foreach ( $choices as $choice_value => $choice_label ) {
 			printf( '<option value="%1$s" %2$s>%3$s</option>', esc_attr( $choice_value ), selected( $value, (string) $choice_value, false ), esc_html( $choice_label ) );
@@ -618,30 +619,6 @@ final class DesignFieldTypes {
 		}
 		$number = (float) $string;
 		return floor( $number ) === $number ? (string) (int) $number : rtrim( rtrim( sprintf( '%.4F', $number ), '0' ), '.' );
-	}
-
-	private static function sub_name( string $field_name, string $key ): string {
-		return $field_name . '[' . $key . ']';
-	}
-
-	private static function sub_template( string $template, string $key ): string {
-		return '' !== $template ? $template . '[' . $key . ']' : '';
-	}
-
-	private static function sub_id( string $input_id, string $key ): string {
-		return $input_id . '__' . sanitize_html_class( str_replace( '_', '-', $key ) );
-	}
-
-	private static function sub_id_template( string $template, string $key ): string {
-		return '' !== $template ? $template . '__' . sanitize_html_class( str_replace( '_', '-', $key ) ) : '';
-	}
-
-	private static function name_attr( string $template ): string {
-		return '' !== $template ? ' data-name-template="' . esc_attr( $template ) . '"' : '';
-	}
-
-	private static function id_attr( string $template ): string {
-		return '' !== $template ? ' data-id-template="' . esc_attr( $template ) . '"' : '';
 	}
 
 	private static function border_styles(): array {

--- a/packages/AdminConfig/src/Framework/FieldTypes/ExtendedPrimitiveFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/ExtendedPrimitiveFieldTypes.php
@@ -12,6 +12,7 @@ namespace Lerm\AdminConfig\Framework\FieldTypes;
 use Lerm\AdminConfig\Framework\Admin\OptionsPage;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
 use Lerm\AdminConfig\Framework\Support\PageSchema;
+use Lerm\AdminConfig\Framework\FieldTypes\Support\FieldRenderHelpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -58,7 +59,7 @@ final class ExtendedPrimitiveFieldTypes {
 			},
 			'render_nested'      => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ): void {
 				if ( self::checkbox_uses_choices( $field ) ) {
-					self::render_checkbox_group( $field, $value, $field_name, false, self::name_attr( self::multiple_name_template( $name_template ) ) );
+					self::render_checkbox_group( $field, $value, $field_name, false, FieldRenderHelpers::name_attr( self::multiple_name_template( $name_template ) ) );
 					return;
 				}
 
@@ -68,8 +69,8 @@ final class ExtendedPrimitiveFieldTypes {
 					$field_name,
 					$input_id,
 					'',
-					self::name_attr( $name_template ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( $name_template ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'           => static function ( array $field, $value, bool $strict, OptionStore $store ) {
@@ -120,8 +121,8 @@ final class ExtendedPrimitiveFieldTypes {
 					$field_name,
 					$input_id,
 					'',
-					self::name_attr( $name_template ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( $name_template ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
@@ -191,8 +192,8 @@ final class ExtendedPrimitiveFieldTypes {
 					$field_name,
 					$input_id,
 					'',
-					self::name_attr( $name_template ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( $name_template ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
@@ -220,7 +221,7 @@ final class ExtendedPrimitiveFieldTypes {
 				);
 			},
 			'render_nested' => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ): void {
-				self::render_spinner_field( $field, $value, $field_name, $input_id, self::name_attr( $name_template ) . self::id_attr( $id_template ) );
+				self::render_spinner_field( $field, $value, $field_name, $input_id, FieldRenderHelpers::name_attr( $name_template ) . FieldRenderHelpers::id_attr( $id_template ) );
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
 				return self::sanitize_numeric_scalar( $field, $value );
@@ -241,7 +242,7 @@ final class ExtendedPrimitiveFieldTypes {
 				self::render_image_select_field( $field, $value, $field_name, true );
 			},
 			'render_nested' => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ): void {
-				self::render_image_select_field( $field, $value, $field_name, false, self::name_attr( $name_template ) );
+				self::render_image_select_field( $field, $value, $field_name, false, FieldRenderHelpers::name_attr( $name_template ) );
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
 				return self::sanitize_select_value( $field, $value, $strict );
@@ -262,7 +263,7 @@ final class ExtendedPrimitiveFieldTypes {
 				self::render_palette_field( $field, $value, $field_name, true );
 			},
 			'render_nested' => static function ( array $field, $value, string $field_name, string $input_id, OptionsPage $page, string $name_template = '', string $id_template = '' ): void {
-				self::render_palette_field( $field, $value, $field_name, false, self::name_attr( $name_template ) );
+				self::render_palette_field( $field, $value, $field_name, false, FieldRenderHelpers::name_attr( $name_template ) );
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ) {
 				$options = self::palette_options( $field );
@@ -395,13 +396,13 @@ final class ExtendedPrimitiveFieldTypes {
 			$data = is_array( $value ) ? $value : array();
 
 			echo '<div class="lerm-date-range">';
-			self::render_date_input( self::sub_name( $field_name, 'from' ), self::sub_id( $input_id, 'from' ), PageSchema::scalar_value( $data['from'] ?? '' ), (string) ( $field['text_from'] ?? __( 'From', 'lerm-admin-config' ) ), self::name_attr( self::sub_template( $name_template, 'from' ) ), self::id_attr( self::sub_id_template( $id_template, 'from' ) ), $extra_attrs );
-			self::render_date_input( self::sub_name( $field_name, 'to' ), self::sub_id( $input_id, 'to' ), PageSchema::scalar_value( $data['to'] ?? '' ), (string) ( $field['text_to'] ?? __( 'To', 'lerm-admin-config' ) ), self::name_attr( self::sub_template( $name_template, 'to' ) ), self::id_attr( self::sub_id_template( $id_template, 'to' ) ) );
+			self::render_date_input( FieldRenderHelpers::sub_name( $field_name, 'from' ), FieldRenderHelpers::sub_id( $input_id, 'from' ), PageSchema::scalar_value( $data['from'] ?? '' ), (string) ( $field['text_from'] ?? __( 'From', 'lerm-admin-config' ) ), FieldRenderHelpers::name_attr( FieldRenderHelpers::sub_template( $name_template, 'from' ) ), FieldRenderHelpers::id_attr( FieldRenderHelpers::sub_id_template( $id_template, 'from' ) ), $extra_attrs );
+			self::render_date_input( FieldRenderHelpers::sub_name( $field_name, 'to' ), FieldRenderHelpers::sub_id( $input_id, 'to' ), PageSchema::scalar_value( $data['to'] ?? '' ), (string) ( $field['text_to'] ?? __( 'To', 'lerm-admin-config' ) ), FieldRenderHelpers::name_attr( FieldRenderHelpers::sub_template( $name_template, 'to' ) ), FieldRenderHelpers::id_attr( FieldRenderHelpers::sub_id_template( $id_template, 'to' ) ) );
 			echo '</div>';
 			return;
 		}
 
-		self::render_date_input( $field_name, $input_id, PageSchema::scalar_value( $value ), '', self::name_attr( $name_template ), self::id_attr( $id_template ), $extra_attrs );
+		self::render_date_input( $field_name, $input_id, PageSchema::scalar_value( $value ), '', FieldRenderHelpers::name_attr( $name_template ), FieldRenderHelpers::id_attr( $id_template ), $extra_attrs );
 	}
 
 	private static function render_date_input( string $field_name, string $input_id, string $value, string $label = '', string $name_attr = '', string $id_attr = '', string $extra_attrs = '' ): void {
@@ -647,31 +648,7 @@ final class ExtendedPrimitiveFieldTypes {
 		return is_scalar( $field['default'] ?? null ) ? (string) $field['default'] : '0';
 	}
 
-	private static function sub_name( string $field_name, string $key ): string {
-		return $field_name . '[' . $key . ']';
-	}
-
-	private static function sub_template( string $template, string $key ): string {
-		return '' !== $template ? $template . '[' . $key . ']' : '';
-	}
-
-	private static function sub_id( string $input_id, string $key ): string {
-		return $input_id . '__' . sanitize_html_class( str_replace( '_', '-', $key ) );
-	}
-
-	private static function sub_id_template( string $template, string $key ): string {
-		return '' !== $template ? $template . '__' . sanitize_html_class( str_replace( '_', '-', $key ) ) : '';
-	}
-
 	private static function multiple_name_template( string $template ): string {
 		return '' !== $template ? $template . '[]' : '';
-	}
-
-	private static function name_attr( string $template ): string {
-		return '' !== $template ? ' data-name-template="' . esc_attr( $template ) . '"' : '';
-	}
-
-	private static function id_attr( string $template ): string {
-		return '' !== $template ? ' data-id-template="' . esc_attr( $template ) . '"' : '';
 	}
 }

--- a/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/StructuredFieldTypes.php
@@ -13,6 +13,7 @@ use Lerm\AdminConfig\Framework\Admin\OptionsPage;
 use Lerm\AdminConfig\Framework\FieldTypes\Support\NestedFieldSanitizer;
 use Lerm\AdminConfig\Framework\Storage\OptionStore;
 use Lerm\AdminConfig\Framework\Support\PageSchema;
+use Lerm\AdminConfig\Framework\FieldTypes\Support\FieldRenderHelpers;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -114,8 +115,8 @@ final class StructuredFieldTypes {
 					$value,
 					$field_name,
 					$input_id,
-					self::name_attr( '' !== $name_template ? $name_template . '[id]' : '' ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( '' !== $name_template ? $name_template . '[id]' : '' ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
@@ -148,8 +149,8 @@ final class StructuredFieldTypes {
 					$value,
 					$field_name,
 					$input_id,
-					self::name_attr( '' !== $name_template ? $name_template . '[ids]' : '' ),
-					self::id_attr( $id_template )
+					FieldRenderHelpers::name_attr( '' !== $name_template ? $name_template . '[ids]' : '' ),
+					FieldRenderHelpers::id_attr( $id_template )
 				);
 			},
 			'sanitize'      => static function ( array $field, $value, bool $strict, OptionStore $store ): array {
@@ -374,8 +375,8 @@ final class StructuredFieldTypes {
 			esc_attr( $field_name ),
 			esc_attr( (string) ( $field['rows'] ?? 10 ) ),
 			esc_attr( (string) ( $field['placeholder'] ?? '' ) ),
-			self::name_attr( $name_template ),
-			self::id_attr( $id_template ),
+			FieldRenderHelpers::name_attr( $name_template ),
+			FieldRenderHelpers::id_attr( $id_template ),
 			esc_textarea( PageSchema::scalar_value( $value ) )
 		);
 	}
@@ -391,8 +392,8 @@ final class StructuredFieldTypes {
 				esc_attr( $input_id ),
 				esc_attr( $field_name ),
 				esc_attr( (string) ( $field['rows'] ?? 6 ) ),
-				self::name_attr( $name_template ),
-				self::id_attr( $id_template ),
+				FieldRenderHelpers::name_attr( $name_template ),
+				FieldRenderHelpers::id_attr( $id_template ),
 				esc_textarea( PageSchema::scalar_value( $value ) )
 			);
 			return;
@@ -649,13 +650,5 @@ final class StructuredFieldTypes {
 			'<p class="description" style="color:#b91c1c;font-style:italic">%s</p>',
 			esc_html( $message )
 		);
-	}
-
-	private static function name_attr( string $name_template ): string {
-		return '' !== $name_template ? ' data-name-template="' . esc_attr( $name_template ) . '"' : '';
-	}
-
-	private static function id_attr( string $id_template ): string {
-		return '' !== $id_template ? ' data-id-template="' . esc_attr( $id_template ) . '"' : '';
 	}
 }

--- a/packages/AdminConfig/src/Framework/FieldTypes/Support/FieldRenderHelpers.php
+++ b/packages/AdminConfig/src/Framework/FieldTypes/Support/FieldRenderHelpers.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Shared rendering helpers for field type classes.
+ *
+ * @package Lerm\AdminConfig
+ */
+
+declare( strict_types=1 );
+
+namespace Lerm\AdminConfig\Framework\FieldTypes\Support;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class FieldRenderHelpers {
+
+	public static function name_attr( string $template ): string {
+		return '' !== $template
+			? ' data-name-template="' . esc_attr( $template ) . '"'
+			: '';
+	}
+
+	public static function id_attr( string $template ): string {
+		return '' !== $template
+			? ' data-id-template="' . esc_attr( $template ) . '"'
+			: '';
+	}
+
+	public static function sub_name( string $field_name, string $key ): string {
+		return $field_name . '[' . $key . ']';
+	}
+
+	public static function sub_template( string $template, string $key ): string {
+		return '' !== $template ? $template . '[' . $key . ']' : '';
+	}
+
+	public static function sub_id( string $input_id, string $key ): string {
+		return $input_id . '__' . sanitize_html_class( str_replace( '_', '-', $key ) );
+	}
+
+	public static function sub_id_template( string $template, string $key ): string {
+		return '' !== $template
+			? $template . '__' . sanitize_html_class( str_replace( '_', '-', $key ) )
+			: '';
+	}
+}

--- a/packages/AdminConfig/src/Rest/Controllers/SchemaController.php
+++ b/packages/AdminConfig/src/Rest/Controllers/SchemaController.php
@@ -39,7 +39,7 @@ final class SchemaController {
 		}
 
 		[ $schema, $store ] = $resolved;
-		$values            = $store->all();
+		$values             = $store->all();
 
 		return rest_ensure_response(
 			array(
@@ -98,7 +98,7 @@ final class SchemaController {
 		}
 
 		[ $schema, $store ] = $resolved;
-		$values            = $store->all();
+		$values             = $store->all();
 
 		return ResponseFactory::success(
 			SchemaSerializer::values( $schema, $values, $this->schema_actions( $schema, $request ) )
@@ -214,7 +214,7 @@ final class SchemaController {
 		}
 
 		[ $schema, $store ] = $resolved;
-		$values            = $store->all();
+		$values             = $store->all();
 
 		$json = wp_json_encode( $values, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 

--- a/packages/AdminConfig/src/Rest/Controllers/SchemaController.php
+++ b/packages/AdminConfig/src/Rest/Controllers/SchemaController.php
@@ -39,7 +39,7 @@ final class SchemaController {
 		}
 
 		[ $schema, $store ] = $resolved;
-		$values = $store->all();
+		$values            = $store->all();
 
 		return rest_ensure_response(
 			array(
@@ -98,7 +98,7 @@ final class SchemaController {
 		}
 
 		[ $schema, $store ] = $resolved;
-		$values = $store->all();
+		$values            = $store->all();
 
 		return ResponseFactory::success(
 			SchemaSerializer::values( $schema, $values, $this->schema_actions( $schema, $request ) )
@@ -214,7 +214,7 @@ final class SchemaController {
 		}
 
 		[ $schema, $store ] = $resolved;
-		$values = $store->all();
+		$values            = $store->all();
 
 		$json = wp_json_encode( $values, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 

--- a/packages/AdminConfig/src/Rest/Controllers/SchemaController.php
+++ b/packages/AdminConfig/src/Rest/Controllers/SchemaController.php
@@ -15,6 +15,7 @@ use Lerm\AdminConfig\Framework\Support\PageSchema;
 use Lerm\AdminConfig\Rest\Support\ContextResolver;
 use Lerm\AdminConfig\Rest\Support\RequestPayload;
 use Lerm\AdminConfig\Rest\Support\ResponseFactory;
+use Lerm\AdminConfig\Framework\Storage\OptionStore;
 use Lerm\AdminConfig\Stores\MissingStoreContextException;
 use Lerm\AdminConfig\WordPress\Runtime;
 use Lerm\AdminConfig\WordPress\Support\ValidationFlash;
@@ -31,17 +32,14 @@ final class SchemaController {
 	}
 
 	public function schema( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
-		$schema = $this->schema_from_request( $request );
+		$resolved = $this->resolve_store( $request );
 
-		if ( is_wp_error( $schema ) ) {
-			return $schema;
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
 		}
 
-		try {
-			$values = $this->runtime->store( $schema->id(), ContextResolver::from_request( $request ) )->all();
-		} catch ( MissingStoreContextException $exception ) {
-			return $this->missing_context_error( $exception );
-		}
+		[ $schema, $store ] = $resolved;
+		$values = $store->all();
 
 		return rest_ensure_response(
 			array(
@@ -93,17 +91,14 @@ final class SchemaController {
 	}
 
 	public function values( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
-		$schema = $this->schema_from_request( $request );
+		$resolved = $this->resolve_store( $request );
 
-		if ( is_wp_error( $schema ) ) {
-			return $schema;
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
 		}
 
-		try {
-			$values = $this->runtime->store( $schema->id(), ContextResolver::from_request( $request ) )->all();
-		} catch ( MissingStoreContextException $exception ) {
-			return $this->missing_context_error( $exception );
-		}
+		[ $schema, $store ] = $resolved;
+		$values = $store->all();
 
 		return ResponseFactory::success(
 			SchemaSerializer::values( $schema, $values, $this->schema_actions( $schema, $request ) )
@@ -111,17 +106,13 @@ final class SchemaController {
 	}
 
 	public function save( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
-		$schema = $this->schema_from_request( $request );
+		$resolved = $this->resolve_store( $request );
 
-		if ( is_wp_error( $schema ) ) {
-			return $schema;
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
 		}
 
-		try {
-			$store = $this->runtime->store( $schema->id(), ContextResolver::from_request( $request ) );
-		} catch ( MissingStoreContextException $exception ) {
-			return $this->missing_context_error( $exception );
-		}
+		[ $schema, $store ] = $resolved;
 
 		$submitted = RequestPayload::values( $request, $store->storage_key() );
 
@@ -161,17 +152,13 @@ final class SchemaController {
 	}
 
 	public function reset( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
-		$schema = $this->schema_from_request( $request );
+		$resolved = $this->resolve_store( $request );
 
-		if ( is_wp_error( $schema ) ) {
-			return $schema;
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
 		}
 
-		try {
-			$store = $this->runtime->store( $schema->id(), ContextResolver::from_request( $request ) );
-		} catch ( MissingStoreContextException $exception ) {
-			return $this->missing_context_error( $exception );
-		}
+		[ $schema, $store ] = $resolved;
 
 		$section    = $this->posted_section( $request, $schema );
 		$subsection = RequestPayload::string( $request, 'subsection', RequestPayload::string( $request, 'lerm_settings_subsection' ) );
@@ -220,17 +207,14 @@ final class SchemaController {
 	}
 
 	public function export( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
-		$schema = $this->schema_from_request( $request );
+		$resolved = $this->resolve_store( $request );
 
-		if ( is_wp_error( $schema ) ) {
-			return $schema;
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
 		}
 
-		try {
-			$values = $this->runtime->store( $schema->id(), ContextResolver::from_request( $request ) )->all();
-		} catch ( MissingStoreContextException $exception ) {
-			return $this->missing_context_error( $exception );
-		}
+		[ $schema, $store ] = $resolved;
+		$values = $store->all();
 
 		$json = wp_json_encode( $values, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 
@@ -251,17 +235,13 @@ final class SchemaController {
 	}
 
 	public function import( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
-		$schema = $this->schema_from_request( $request );
+		$resolved = $this->resolve_store( $request );
 
-		if ( is_wp_error( $schema ) ) {
-			return $schema;
+		if ( is_wp_error( $resolved ) ) {
+			return $resolved;
 		}
 
-		try {
-			$store = $this->runtime->store( $schema->id(), ContextResolver::from_request( $request ) );
-		} catch ( MissingStoreContextException $exception ) {
-			return $this->missing_context_error( $exception );
-		}
+		[ $schema, $store ] = $resolved;
 
 		$json = RequestPayload::string( $request, 'backup_json', RequestPayload::string( $request, 'json' ) );
 
@@ -517,6 +497,25 @@ final class SchemaController {
 		}
 
 		return $selected;
+	}
+
+	/**
+	 * @return array{0: CompiledSchema, 1: OptionStore}|\WP_Error
+	 */
+	private function resolve_store( \WP_REST_Request $request ): array|\WP_Error {
+		$schema = $this->schema_from_request( $request );
+		if ( is_wp_error( $schema ) ) {
+			return $schema;
+		}
+		try {
+			$store = $this->runtime->store(
+				$schema->id(),
+				ContextResolver::from_request( $request )
+			);
+		} catch ( MissingStoreContextException $e ) {
+			return $this->missing_context_error( $e );
+		}
+		return array( $schema, $store );
 	}
 
 	private function missing_context_error( MissingStoreContextException $exception ): \WP_Error {

--- a/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/CommentContainer.php
@@ -156,7 +156,7 @@ final class CommentContainer implements Container {
 				continue;
 			}
 
-			if ( ! current_user_can( $this->capability_for_schema( $schema ), $comment_id ) ) {
+			if ( ! current_user_can( ContainerSaveSupport::capability_for_schema( $schema, 'edit_comment' ), $comment_id ) ) {
 				continue;
 			}
 
@@ -190,16 +190,6 @@ final class CommentContainer implements Container {
 			false,
 			$this->framework->field_modules()
 		);
-	}
-
-	private function capability_for_schema( CompiledSchema $schema ): string {
-		$container = $schema->container();
-
-		if ( ! empty( $container['capability'] ) && is_scalar( $container['capability'] ) ) {
-			return (string) $container['capability'];
-		}
-
-		return 'edit_comment';
 	}
 
 	private function meta_box_id( CompiledSchema $schema ): string {

--- a/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/MetaboxContainer.php
@@ -175,9 +175,7 @@ final class MetaboxContainer implements Container, BlockEditorPanelContext {
 				continue;
 			}
 
-			$capability = (string) ( $container['capability'] ?? 'edit_post' );
-
-			if ( ! current_user_can( $capability, $post_id ) ) {
+			if ( ! current_user_can( ContainerSaveSupport::capability_for_schema( $schema, 'edit_post' ), $post_id ) ) {
 				continue;
 			}
 

--- a/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
@@ -166,5 +166,4 @@ final class ProfileContainer implements Container {
 			$this->framework->field_modules()
 		);
 	}
-
 }

--- a/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
+++ b/packages/AdminConfig/src/WordPress/Containers/ProfileContainer.php
@@ -136,7 +136,7 @@ final class ProfileContainer implements Container {
 				continue;
 			}
 
-			if ( ! current_user_can( $this->capability_for_schema( $schema ), $user_id ) ) {
+			if ( ! current_user_can( ContainerSaveSupport::capability_for_schema( $schema, 'edit_user' ), $user_id ) ) {
 				continue;
 			}
 
@@ -167,13 +167,4 @@ final class ProfileContainer implements Container {
 		);
 	}
 
-	private function capability_for_schema( CompiledSchema $schema ): string {
-		$container = $schema->container();
-
-		if ( ! empty( $container['capability'] ) && is_scalar( $container['capability'] ) ) {
-			return (string) $container['capability'];
-		}
-
-		return 'edit_user';
-	}
 }

--- a/packages/AdminConfig/src/WordPress/Support/ContainerSaveSupport.php
+++ b/packages/AdminConfig/src/WordPress/Support/ContainerSaveSupport.php
@@ -119,4 +119,18 @@ final class ContainerSaveSupport {
 
 		return array_values( array_unique( $normalized ) );
 	}
+
+	/**
+	 * Read the capability declared in the schema container, falling back
+	 * to the caller-supplied default when no explicit capability is set.
+	 */
+	public static function capability_for_schema( CompiledSchema $schema, string $fallback ): string {
+		$container = $schema->container();
+
+		if ( ! empty( $container['capability'] ) && is_scalar( $container['capability'] ) ) {
+			return (string) $container['capability'];
+		}
+
+		return $fallback;
+	}
 }


### PR DESCRIPTION
## Summary

Three rounds of duplicate code elimination across the AdminConfig package.

### 1. SchemaController::resolve_store()

The 10-line schema-from-request + store-resolve + MissingStoreContextException pattern was repeated verbatim in 6 methods (`schema()`, `values()`, `save()`, `reset()`, `export()`, `import()`). Extracted into a private `resolve_store()` returning `[CompiledSchema, OptionStore] | WP_Error`.

Call sites reduced from 10 lines to 3:
```php
$resolved = $this->resolve_store( $request );
if ( is_wp_error( $resolved ) ) { return $resolved; }
[ $schema, $store ] = $resolved;
```

### 2. ContainerSaveSupport::capability_for_schema()

Identical private `capability_for_schema()` methods in CommentContainer and ProfileContainer, plus inline logic in MetaboxContainer, replaced with a shared static method accepting a fallback capability string:
```php
ContainerSaveSupport::capability_for_schema( $schema, 'edit_comment' )
ContainerSaveSupport::capability_for_schema( $schema, 'edit_user' )
ContainerSaveSupport::capability_for_schema( $schema, 'edit_post' )
```
TaxonomyContainer keeps its private variant (extra `get_taxonomy()` logic).

### 3. FieldRenderHelpers (new file)

6 shared rendering helpers — `name_attr`, `id_attr`, `sub_name`, `sub_id`, `sub_template`, `sub_id_template` — previously copy-pasted across 5 field type files. Centralized in `Support\FieldRenderHelpers`.

### Stats

| Files | + | − | Net |
|-------|---|---|-----|
| 11 | 169 | 197 | −28 |

All 112 PHPUnit tests pass (447 assertions).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)